### PR TITLE
Preserve severity level when calling WithData on a logger instance

### DIFF
--- a/Logfmt.Tests/LogfmtTests.cs
+++ b/Logfmt.Tests/LogfmtTests.cs
@@ -205,5 +205,25 @@ namespace Logfmt.Tests
       Assert.Contains("color=blue", output);
       Assert.Contains("country=\"United States\"", output);
     }
+
+    /// <summary>
+    /// Testing debug output mode with default fields.
+    /// </summary>
+    [Fact]
+    public void LogDebugOutputWithDefaultFieldsTest()
+    {
+        var outputStream = new MemoryStream();
+        var logger = new Logger(outputStream, SeverityLevel.Debug).WithData(new KeyValuePair<string, string>("module", "foo"));
+
+        // write a log entry
+        logger.Debug(msg: "hello logs!");
+
+        outputStream.Seek(0, SeekOrigin.Begin);
+        var reader = new StreamReader(outputStream);
+
+        var output = reader.ReadLine();
+
+        Assert.Contains("level=debug msg=\"hello logs!\" module=foo", output);
+    }
   }
 }

--- a/logfmt/Logger.cs
+++ b/logfmt/Logger.cs
@@ -70,7 +70,7 @@ namespace Logfmt
     /// <returns>A new <see cref="Logfmt.Logger"/> instance.</returns>
     public Logger WithData(params KeyValuePair<string, string>[] kvpairs)
     {
-      var newLogger = new Logger(outputStream)
+      var newLogger = new Logger(outputStream, this.levelFilter)
       {
         includedData = includedData,
       };


### PR DESCRIPTION
When calling "WithData" on a logger instance, it does not take care of the severity level the logger has been created with. Here is a suggested change, please feel to let me know if that makes sense. Thanks !