### PR TITLE
ci: Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+          10.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+
+    - name: Test
+      run: dotnet test --no-build --configuration Release --verbosity normal
+
+    - name: Pack
+      run: dotnet pack Logfmt/Logfmt.csproj --no-build --configuration Release --output ./artifacts
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release create "${{ github.ref_name }}" ./artifacts/*.nupkg --generate-notes
+
+    - name: Push to NuGet.org
+      if: env.NUGET_API_KEY != ''
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push ./artifacts/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Adds a GitHub Actions workflow that automates releases when a version tag is pushed.

## How it works

1. Push a tag: `git tag v0.4.1 && git push origin v0.4.1`
2. Workflow runs: build → test → pack → release
3. GitHub Release is created with auto-generated notes and the `.nupkg` attached
4. If `NUGET_API_KEY` secret is configured, the package is also pushed to NuGet.org

## Details

- **Trigger:** `v*` tags only
- **Permissions:** `contents: write` for creating releases
- **NuGet.org:** Opt-in via `NUGET_API_KEY` repository secret (skipped if not set)
- **Existing CI:** `dotnet.yml` is unchanged — it continues to run on pushes/PRs to main