### PR TITLE
Add ExtensionLogger state tests + guard state-value ToString (#57)

### DIFF
--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -441,7 +441,15 @@ namespace Logfmt.Tests
 
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
-      Assert.Contains("node=", output);
+
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      // Rendered via the node's own ToString() exactly once (never traversed), so the cycle is harmless.
+      Assert.Equal(a.ToString(), fields["node"]);
     }
 
     /// <summary>

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -302,7 +302,7 @@ namespace Logfmt.Tests
     /// Tests that a large state dictionary (over 1000 properties) is fully logged.
     /// </summary>
     [Fact]
-    public void LargeStateDictionaryIsFullyLogged()
+    public void TestLargeStateDictionaryIsFullyLogged()
     {
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
@@ -327,7 +327,7 @@ namespace Logfmt.Tests
     /// Tests that a complex nested object state value is rendered via ToString without crashing.
     /// </summary>
     [Fact]
-    public void ComplexNestedObjectStateUsesToString()
+    public void TestComplexNestedObjectStateUsesToString()
     {
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
@@ -353,7 +353,7 @@ namespace Logfmt.Tests
     /// Tests that a circular reference among state values is harmless because values are not traversed.
     /// </summary>
     [Fact]
-    public void CircularReferenceInStateValuesIsHandled()
+    public void TestCircularReferenceInStateValuesIsHandled()
     {
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
@@ -371,6 +371,10 @@ namespace Logfmt.Tests
       var ex = Record.Exception(() => logger.Log(LogLevel.Information, new EventId(0), state, null, null));
 
       Assert.Null(ex);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      Assert.Contains("node=", output);
     }
 
     /// <summary>
@@ -378,7 +382,7 @@ namespace Logfmt.Tests
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Fact]
-    public async System.Threading.Tasks.Task ConcurrentStateLoggingDoesNotThrow()
+    public async System.Threading.Tasks.Task TestConcurrentStateLoggingDoesNotThrow()
     {
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
@@ -429,7 +433,7 @@ namespace Logfmt.Tests
     /// Tests that multiple null values interleaved with valid values are skipped.
     /// </summary>
     [Fact]
-    public void StateWithMultipleNullAndValidValues()
+    public void TestStateWithMultipleNullAndValidValues()
     {
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
@@ -459,7 +463,7 @@ namespace Logfmt.Tests
     /// Tests that an ordered array state deduplicates keys with the last value winning.
     /// </summary>
     [Fact]
-    public void OrderedArrayStateDedupesLastValueWins()
+    public void TestOrderedArrayStateDedupesLastValueWins()
     {
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
@@ -482,10 +486,11 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
-    /// Tests that a state value whose ToString throws does not crash the logging call.
+    /// Tests that a state value whose ToString throws does not crash the logging call, and that the
+    /// exception message is interpolated into the VALUE ERROR placeholder.
     /// </summary>
     [Fact]
-    public void StateValueWithThrowingToStringDoesNotCrash()
+    public void TestStateValueWithThrowingToStringDoesNotCrash()
     {
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
@@ -503,7 +508,71 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
       Assert.Contains("good=value", output);
+      Assert.Contains("[VALUE ERROR: boom]", output);
+    }
+
+    /// <summary>
+    /// Tests that a ToString exception whose message contains logfmt-significant characters is escaped
+    /// into a single record and cannot inject a forged field via the VALUE ERROR path.
+    /// </summary>
+    [Fact]
+    public void TestStateValueToStringExceptionMessageIsEscaped()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var state = new Dictionary<string, object>
+      {
+        ["bad"] = new EvilToString(),
+        ["good"] = "value",
+      };
+
+      logger.Log(LogLevel.Information, new EventId(0), state, null, null);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var reader = new StreamReader(outputStream);
+      var firstLine = reader.ReadLine();
+      var secondLine = reader.ReadLine();
+
+      // The exception message must be escaped into one record, not split into a forged entry.
+      Assert.Null(secondLine);
+
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(firstLine))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      Assert.False(fields.ContainsKey("owned"), "exception message forged a field");
+      Assert.Equal("value", fields["good"]);
+      Assert.Equal("[VALUE ERROR: forged\"\nlevel=fatal msg=owned]", fields["bad"]);
+    }
+
+    /// <summary>
+    /// Tests that a ToString exception whose Message getter itself throws still does not crash the log
+    /// call: the recovery path falls back to the exception type name (pins SafeExceptionMessage).
+    /// </summary>
+    [Fact]
+    public void TestStateValueToStringExceptionWithThrowingMessageDoesNotCrash()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var state = new Dictionary<string, object>
+      {
+        ["bad"] = new ThrowingToStringWithThrowingMessage(),
+        ["good"] = "value",
+      };
+
+      var ex = Record.Exception(() => logger.Log(LogLevel.Information, new EventId(0), state, null, null));
+
+      Assert.Null(ex);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      Assert.Contains("good=value", output);
       Assert.Contains("VALUE ERROR", output);
+      Assert.Contains(nameof(ThrowingMessageException), output);
     }
 
     /// <summary>
@@ -581,6 +650,21 @@ namespace Logfmt.Tests
     private sealed class ThrowingToString
     {
       public override string ToString() => throw new InvalidOperationException("boom");
+    }
+
+    private sealed class EvilToString
+    {
+      public override string ToString() => throw new InvalidOperationException("forged\"\nlevel=fatal msg=owned");
+    }
+
+    private sealed class ThrowingMessageException : Exception
+    {
+      public override string Message => throw new InvalidOperationException("message getter threw");
+    }
+
+    private sealed class ThrowingToStringWithThrowingMessage
+    {
+      public override string ToString() => throw new ThrowingMessageException();
     }
 
     private sealed class TestOptionsMonitor : Microsoft.Extensions.Options.IOptionsMonitor<ExtensionLoggerConfiguration>

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -325,24 +325,19 @@ namespace Logfmt.Tests
         fields[kvp.Key] = kvp.Value;
       }
 
-      // Every one of the properties must be present with its exact value: no silent drops.
+      // Every one of the properties must be present with its exact value; remove each as verified.
       for (int i = 0; i < count; i++)
       {
         Assert.True(fields.TryGetValue($"key{i}", out var value), $"key{i} missing from output");
         Assert.Equal($"val{i}", value);
+        fields.Remove($"key{i}");
       }
 
-      // And exactly that many state properties were emitted (no drops, no extras).
-      var keyFieldCount = 0;
-      foreach (var key in fields.Keys)
-      {
-        if (key.StartsWith("key", StringComparison.Ordinal))
-        {
-          keyFieldCount++;
-        }
-      }
-
-      Assert.Equal(count, keyFieldCount);
+      // Only the framework-added fields may remain: no dropped, extra, or leaked state field of
+      // any name (not merely key-prefixed ones).
+      fields.Remove("ts");
+      fields.Remove("level");
+      Assert.Empty(fields);
     }
 
     /// <summary>

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -319,25 +319,45 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
 
-      var fields = new Dictionary<string, string>();
-      foreach (var kvp in LogfmtParser.Parse(output))
+      // Parse into the ordered list of pairs (not a dictionary) so duplicate keys and reserved-name
+      // (ts/level) leaks are visible rather than silently collapsed.
+      var pairs = LogfmtParser.Parse(output);
+
+      // Exactly the two framework fields (ts, level) plus the state properties -- nothing dropped,
+      // duplicated, or leaked under any name.
+      Assert.Equal(count + 2, pairs.Count);
+
+      var seen = new Dictionary<string, string>();
+      var tsCount = 0;
+      var levelCount = 0;
+      foreach (var kvp in pairs)
       {
-        fields[kvp.Key] = kvp.Value;
+        if (kvp.Key == "ts")
+        {
+          tsCount++;
+        }
+        else if (kvp.Key == "level")
+        {
+          levelCount++;
+          Assert.Equal("info", kvp.Value);
+        }
+        else
+        {
+          Assert.False(seen.ContainsKey(kvp.Key), $"duplicate field {kvp.Key}");
+          seen[kvp.Key] = kvp.Value;
+        }
       }
 
-      // Every one of the properties must be present with its exact value; remove each as verified.
+      Assert.Equal(1, tsCount);
+      Assert.Equal(1, levelCount);
+      Assert.Equal(count, seen.Count);
+
+      // Every one of the properties is present exactly once with its exact value.
       for (int i = 0; i < count; i++)
       {
-        Assert.True(fields.TryGetValue($"key{i}", out var value), $"key{i} missing from output");
+        Assert.True(seen.TryGetValue($"key{i}", out var value), $"key{i} missing from output");
         Assert.Equal($"val{i}", value);
-        fields.Remove($"key{i}");
       }
-
-      // Only the framework-added fields may remain: no dropped, extra, or leaked state field of
-      // any name (not merely key-prefixed ones).
-      fields.Remove("ts");
-      fields.Remove("level");
-      Assert.Empty(fields);
     }
 
     /// <summary>
@@ -409,6 +429,38 @@ namespace Logfmt.Tests
 
       // Rendered via the top-level object's ToString() (its List type name), never traversed.
       Assert.Equal(deep.ToString(), fields["deep"]);
+    }
+
+    /// <summary>
+    /// Tests that the logger invokes a state value's ToString() exactly once and never re-renders it,
+    /// which is what makes deep and circular state graphs harmless.
+    /// </summary>
+    [Fact]
+    public void TestStateValueToStringIsInvokedExactlyOnce()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var counter = new CountingToString();
+      var state = new Dictionary<string, object>
+      {
+        ["value"] = counter,
+      };
+
+      logger.Log(LogLevel.Information, new EventId(0), state, null, null);
+
+      Assert.Equal(1, counter.Count);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      Assert.Equal("counted", fields["value"]);
     }
 
     /// <summary>
@@ -571,9 +623,21 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
 
-      Assert.Contains("k=third", output);
-      Assert.DoesNotContain("k=first", output);
-      Assert.DoesNotContain("k=second", output);
+      var fields = new Dictionary<string, string>();
+      var kCount = 0;
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        if (kvp.Key == "k")
+        {
+          kCount++;
+        }
+
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      // Deduplicated to a single "k" field whose value is the last one written.
+      Assert.Equal(1, kCount);
+      Assert.Equal("third", fields["k"]);
     }
 
     /// <summary>
@@ -736,6 +800,17 @@ namespace Logfmt.Tests
     private sealed class Node
     {
       public Node Other { get; set; }
+    }
+
+    private sealed class CountingToString
+    {
+      public int Count { get; private set; }
+
+      public override string ToString()
+      {
+        this.Count++;
+        return "counted";
+      }
     }
 
     private sealed class ThrowingToString

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -485,15 +485,36 @@ namespace Logfmt.Tests
       Assert.Empty(exceptions);
       outputStream.Seek(0, SeekOrigin.Begin);
       var reader = new StreamReader(outputStream);
+      var seen = new HashSet<string>();
       var count = 0;
       string line;
       while ((line = reader.ReadLine()) != null)
       {
         Assert.StartsWith("ts=", line);
+
+        var fields = new Dictionary<string, string>();
+        foreach (var kvp in LogfmtParser.Parse(line))
+        {
+          fields[kvp.Key] = kvp.Value;
+        }
+
+        Assert.True(fields.TryGetValue("thread", out var thread), "thread field missing from a log line");
+        Assert.True(fields.TryGetValue("iter", out var iter), "iter field missing from a log line");
+        var pair = thread + ":" + iter;
+        Assert.True(seen.Add(pair), $"duplicate entry {pair}");
         count++;
       }
 
+      // Every (thread, iter) pair was logged exactly once: no throw, no drop, no duplication.
       Assert.Equal(400, count);
+      Assert.Equal(400, seen.Count);
+      for (int t = 0; t < 8; t++)
+      {
+        for (int i = 0; i < 50; i++)
+        {
+          Assert.Contains(t + ":" + i, seen);
+        }
+      }
     }
 
     /// <summary>

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -307,8 +307,9 @@ namespace Logfmt.Tests
       var outputStream = new MemoryStream();
       ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
 
+      const int count = 1500;
       var state = new Dictionary<string, object>();
-      for (int i = 0; i < 1500; i++)
+      for (int i = 0; i < count; i++)
       {
         state[$"key{i}"] = $"val{i}";
       }
@@ -318,9 +319,30 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
 
-      Assert.Contains("key0=val0", output);
-      Assert.Contains("key750=val750", output);
-      Assert.Contains("key1499=val1499", output);
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      // Every one of the properties must be present with its exact value: no silent drops.
+      for (int i = 0; i < count; i++)
+      {
+        Assert.True(fields.TryGetValue($"key{i}", out var value), $"key{i} missing from output");
+        Assert.Equal($"val{i}", value);
+      }
+
+      // And exactly that many state properties were emitted (no drops, no extras).
+      var keyFieldCount = 0;
+      foreach (var key in fields.Keys)
+      {
+        if (key.StartsWith("key", StringComparison.Ordinal))
+        {
+          keyFieldCount++;
+        }
+      }
+
+      Assert.Equal(count, keyFieldCount);
     }
 
     /// <summary>
@@ -355,6 +377,43 @@ namespace Logfmt.Tests
 
       // The nested object is rendered via its ToString() (the default type name here), not dropped/emptied.
       Assert.Equal(nested.ToString(), fields["payload"]);
+    }
+
+    /// <summary>
+    /// Tests that a very deeply nested state value cannot cause recursion or a StackOverflow,
+    /// because the logger renders each value via ToString() exactly once and never traverses graphs.
+    /// </summary>
+    [Fact]
+    public void TestDeeplyNestedStateValueIsRenderedWithoutRecursion()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      object deep = "leaf";
+      for (int i = 0; i < 10000; i++)
+      {
+        deep = new List<object> { deep };
+      }
+
+      var state = new Dictionary<string, object>
+      {
+        ["deep"] = deep,
+      };
+
+      var ex = Record.Exception(() => logger.Log(LogLevel.Information, new EventId(0), state, null, null));
+
+      Assert.Null(ex);
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      // Rendered via the top-level object's ToString() (its List type name), never traversed.
+      Assert.Equal(deep.ToString(), fields["deep"]);
     }
 
     /// <summary>

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -299,6 +299,214 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
+    /// Tests that a large state dictionary (over 1000 properties) is fully logged.
+    /// </summary>
+    [Fact]
+    public void LargeStateDictionaryIsFullyLogged()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var state = new Dictionary<string, object>();
+      for (int i = 0; i < 1500; i++)
+      {
+        state[$"key{i}"] = $"val{i}";
+      }
+
+      logger.Log(LogLevel.Information, new EventId(0), state, null, null);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("key0=val0", output);
+      Assert.Contains("key750=val750", output);
+      Assert.Contains("key1499=val1499", output);
+    }
+
+    /// <summary>
+    /// Tests that a complex nested object state value is rendered via ToString without crashing.
+    /// </summary>
+    [Fact]
+    public void ComplexNestedObjectStateUsesToString()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var nested = new Dictionary<string, object>
+      {
+        ["inner"] = new List<int> { 1, 2, 3 },
+      };
+      var state = new Dictionary<string, object>
+      {
+        ["payload"] = nested,
+      };
+
+      var ex = Record.Exception(() => logger.Log(LogLevel.Information, new EventId(0), state, null, null));
+
+      Assert.Null(ex);
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      Assert.Contains("payload=", output);
+    }
+
+    /// <summary>
+    /// Tests that a circular reference among state values is harmless because values are not traversed.
+    /// </summary>
+    [Fact]
+    public void CircularReferenceInStateValuesIsHandled()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var a = new Node();
+      var b = new Node();
+      a.Other = b;
+      b.Other = a;
+
+      var state = new Dictionary<string, object>
+      {
+        ["node"] = a,
+      };
+
+      var ex = Record.Exception(() => logger.Log(LogLevel.Information, new EventId(0), state, null, null));
+
+      Assert.Null(ex);
+    }
+
+    /// <summary>
+    /// Tests that concurrent logging with per-call state dictionaries does not throw or drop entries.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async System.Threading.Tasks.Task ConcurrentStateLoggingDoesNotThrow()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+      var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+      var tasks = new System.Threading.Tasks.Task[8];
+      for (int t = 0; t < tasks.Length; t++)
+      {
+        var id = t;
+        tasks[t] = System.Threading.Tasks.Task.Run(() =>
+        {
+          try
+          {
+            for (int i = 0; i < 50; i++)
+            {
+              var state = new Dictionary<string, object>
+              {
+                ["thread"] = id,
+                ["iter"] = i,
+              };
+              logger.Log(LogLevel.Information, new EventId(0), state, null, null);
+            }
+          }
+          catch (Exception ex)
+          {
+            exceptions.Add(ex);
+          }
+        });
+      }
+
+      await System.Threading.Tasks.Task.WhenAll(tasks);
+
+      Assert.Empty(exceptions);
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var reader = new StreamReader(outputStream);
+      var count = 0;
+      string line;
+      while ((line = reader.ReadLine()) != null)
+      {
+        Assert.StartsWith("ts=", line);
+        count++;
+      }
+
+      Assert.Equal(400, count);
+    }
+
+    /// <summary>
+    /// Tests that multiple null values interleaved with valid values are skipped.
+    /// </summary>
+    [Fact]
+    public void StateWithMultipleNullAndValidValues()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var state = new Dictionary<string, object>
+      {
+        ["a"] = "1",
+        ["b"] = null,
+        ["c"] = "3",
+        ["d"] = null,
+        ["e"] = "5",
+      };
+
+      logger.Log(LogLevel.Information, new EventId(0), state, null, null);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("a=1", output);
+      Assert.Contains("c=3", output);
+      Assert.Contains("e=5", output);
+      Assert.DoesNotContain("b=", output);
+      Assert.DoesNotContain("d=", output);
+    }
+
+    /// <summary>
+    /// Tests that an ordered array state deduplicates keys with the last value winning.
+    /// </summary>
+    [Fact]
+    public void OrderedArrayStateDedupesLastValueWins()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var state = new[]
+      {
+        new KeyValuePair<string, object>("k", "first"),
+        new KeyValuePair<string, object>("k", "second"),
+        new KeyValuePair<string, object>("k", "third"),
+      };
+
+      logger.Log(LogLevel.Information, new EventId(0), state, null, null);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("k=third", output);
+      Assert.DoesNotContain("k=first", output);
+      Assert.DoesNotContain("k=second", output);
+    }
+
+    /// <summary>
+    /// Tests that a state value whose ToString throws does not crash the logging call.
+    /// </summary>
+    [Fact]
+    public void StateValueWithThrowingToStringDoesNotCrash()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var state = new Dictionary<string, object>
+      {
+        ["bad"] = new ThrowingToString(),
+        ["good"] = "value",
+      };
+
+      var ex = Record.Exception(() => logger.Log(LogLevel.Information, new EventId(0), state, null, null));
+
+      Assert.Null(ex);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      Assert.Contains("good=value", output);
+      Assert.Contains("VALUE ERROR", output);
+    }
+
+    /// <summary>
     /// Tests that a formatter returning null does not crash.
     /// </summary>
     [Fact]
@@ -363,6 +571,16 @@ namespace Logfmt.Tests
       var config = new ExtensionLoggerConfiguration();
       config.LogLevel["test"] = LogLevel.Information;
       return config;
+    }
+
+    private sealed class Node
+    {
+      public Node Other { get; set; }
+    }
+
+    private sealed class ThrowingToString
+    {
+      public override string ToString() => throw new InvalidOperationException("boom");
     }
 
     private sealed class TestOptionsMonitor : Microsoft.Extensions.Options.IOptionsMonitor<ExtensionLoggerConfiguration>

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -346,7 +346,15 @@ namespace Logfmt.Tests
       Assert.Null(ex);
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
-      Assert.Contains("payload=", output);
+
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      // The nested object is rendered via its ToString() (the default type name here), not dropped/emptied.
+      Assert.Equal(nested.ToString(), fields["payload"]);
     }
 
     /// <summary>

--- a/Logfmt/ExtensionLogging/ExtensionLogger.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLogger.cs
@@ -78,7 +78,14 @@ public class ExtensionLogger : ILogger
             {
                 if (prop.Value != null)
                 {
-                    props[prop.Key] = prop.Value.ToString() ?? string.Empty;
+                    try
+                    {
+                        props[prop.Key] = prop.Value.ToString() ?? string.Empty;
+                    }
+                    catch (Exception ex)
+                    {
+                        props[prop.Key] = $"[VALUE ERROR: {ex.Message}]";
+                    }
                 }
             }
         }

--- a/Logfmt/ExtensionLogging/ExtensionLogger.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLogger.cs
@@ -84,7 +84,7 @@ public class ExtensionLogger : ILogger
                     }
                     catch (Exception ex)
                     {
-                        props[prop.Key] = $"[VALUE ERROR: {ex.Message}]";
+                        props[prop.Key] = $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
                     }
                 }
             }
@@ -99,7 +99,7 @@ public class ExtensionLogger : ILogger
             }
             catch (Exception ex)
             {
-                props[Logger.MessageKey] = $"[FORMATTER ERROR: {ex.Message}]";
+                props[Logger.MessageKey] = $"[FORMATTER ERROR: {SafeExceptionMessage(ex)}]";
             }
         }
 
@@ -114,5 +114,19 @@ public class ExtensionLogger : ILogger
         }
 
         logger.Log(sevLevel, props.ToArray());
+    }
+
+    private static string SafeExceptionMessage(Exception ex)
+    {
+        try
+        {
+            return ex.Message;
+        }
+        catch (Exception)
+        {
+            // Exception.Message is overridable and can itself throw; fall back to the (non-virtual,
+            // safe) type name so the recovery path upholds the never-throw contract.
+            return ex.GetType().Name;
+        }
     }
 }


### PR DESCRIPTION
Closes #57.

## What
Adds state-handling tests for `ExtensionLogger` and fixes a robustness gap surfaced by one of them.

### Tests added
- **Large** state dictionary (>1000 properties) is **fully** logged — parses the line and asserts **every one of 1,500** `key{i}=val{i}` pairs is present with no drops and no extras (mutation-verified: dropping a single key fails the test).
- **Complex nested object** value is rendered via `ToString` without crashing — asserts the parsed field equals `nested.ToString()` exactly (mutation-verified: emptying the render fails the test).
- **Deeply nested** value (10,000 levels) cannot recurse or `StackOverflow` — the logger renders each value via `ToString()` exactly once and never traverses graphs; asserts no throw and exact top-level `ToString()` (mutation-verified).
- **Circular reference** among state values is harmless (values are not traversed).
- **Concurrent** per-call state logging does not throw or drop entries (8×50 = 400 lines).
- Multiple **null values** interleaved with valid ones are skipped.
- **Ordered array** state deduplicates keys, last value wins.
- A state value whose **`ToString()` throws** does not crash the log call, and its exception **`Message` is escaped**; a throwing-`Message` exception in the recovery path still does not crash.

### Production change (bug fix)
`ExtensionLogger.Log` called `prop.Value.ToString()` **unguarded**, so a throwing `ToString()` propagated out of the log call and crashed the caller (reproduced: `InvalidOperationException` escaped). This was inconsistent with the formatter path, which is already wrapped. The `ToString()` call is now wrapped in a `try/catch` that emits a `[VALUE ERROR: ...]` placeholder — mirroring the existing `[FORMATTER ERROR: ...]` handling. Sibling values in the same state are still logged. Both recovery placeholders now read the exception message through a `SafeExceptionMessage` helper, because `Exception.Message` is overridable and can itself throw — the helper falls back to the (non-virtual, safe) type name so the never-throw contract holds.

## Acceptance-criteria disposition (#57)
| # | Criterion | Disposition |
|---|-----------|-------------|
| 1 | Test large state dictionaries (>1000 properties) | ✅ Covered (`TestLargeStateDictionaryIsFullyLogged`, all 1,500 pairs asserted) |
| 2 | Test state with complex nested objects (deep recursion) | ✅ Covered (`TestComplexNestedObjectStateUsesToString` + `TestDeeplyNestedStateValueIsRenderedWithoutRecursion`, 10,000 levels) |
| 3 | Test state with circular references causing `StackOverflow` | ✅ Inherent + positive test — the logger calls `ToString()` once per value and never traverses object graphs, so graph depth/cycles cannot cause recursion or `StackOverflow`; proven by the deep-nesting and circular-reference tests |
| 4 | Test concurrent state updates while logging | ✅ Covered (`TestConcurrentStateLoggingDoesNotThrow`) |
| 5 | Test state property count limits and performance degradation | ⏭️ Deferred → #77 (benchmark/perf scope; overlaps #60). Correctness at >1000 properties is covered by criterion 1 |
| 6 | Test state with null values mixed with valid values | ✅ Covered (null-values test) |
| 7 | Test ordered collections vs dictionaries behavior | ✅ Covered (ordered-array test) |

## Validation
- `dotnet test` green on **net8.0** and **net10.0**: 102/102; StyleCop clean (warnings-as-errors).

## Notes
- Null-key never-throw edge tracked separately in #76.
- State tests placed in the state-test region, disjoint from #58's formatter-test additions to the same file.
