### PR TITLE
Add configuration tests + make category matching case-insensitive (#59)

### DIFF
--- a/Logfmt.Tests/ExtensionLoggerConfigurationTests.cs
+++ b/Logfmt.Tests/ExtensionLoggerConfigurationTests.cs
@@ -70,6 +70,30 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
+    /// Tests that an exact category level takes precedence over a conflicting Default level.
+    /// </summary>
+    [Fact]
+    public void SpecificCategoryOverridesDefault()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["Default"] = LogLevel.Error;
+      config.LogLevel["cat"] = LogLevel.Debug;
+      var monitor = new ChangeableOptionsMonitor(config);
+      using var provider = new ExtensionLoggerProvider(monitor);
+
+      // The exact "cat" level (Debug) wins over the more restrictive Default (Error).
+      var logger = provider.CreateLogger("cat");
+      Assert.True(logger.IsEnabled(LogLevel.Debug));
+      Assert.False(logger.IsEnabled(LogLevel.Trace));
+
+      // Control: an unconfigured category falls back to the restrictive Default (Error),
+      // so the assertions above reflect exact-over-Default precedence, not Default alone.
+      var other = provider.CreateLogger("other");
+      Assert.True(other.IsEnabled(LogLevel.Error));
+      Assert.False(other.IsEnabled(LogLevel.Debug));
+    }
+
+    /// <summary>
     /// Tests that an unknown category with no Default configured is disabled.
     /// </summary>
     [Fact]

--- a/Logfmt.Tests/ExtensionLoggerConfigurationTests.cs
+++ b/Logfmt.Tests/ExtensionLoggerConfigurationTests.cs
@@ -26,6 +26,13 @@ namespace Logfmt.Tests
 
       Assert.False(logger.IsEnabled(LogLevel.Information));
       Assert.False(logger.IsEnabled(LogLevel.Error));
+
+      // Positive control: the same provider type does enable a configured category, so the
+      // assertions above reflect the empty config -- not a trivially always-disabled provider.
+      var enabledConfig = new ExtensionLoggerConfiguration();
+      enabledConfig.LogLevel["SomeCategory"] = LogLevel.Information;
+      using var enabledProvider = new ExtensionLoggerProvider(new ChangeableOptionsMonitor(enabledConfig));
+      Assert.True(enabledProvider.CreateLogger("SomeCategory").IsEnabled(LogLevel.Information));
     }
 
     /// <summary>
@@ -42,6 +49,7 @@ namespace Logfmt.Tests
       var logger = provider.CreateLogger("cat");
 
       Assert.True(logger.IsEnabled(LogLevel.Debug));
+      Assert.False(logger.IsEnabled(LogLevel.Trace));
     }
 
     /// <summary>
@@ -75,6 +83,12 @@ namespace Logfmt.Tests
 
       Assert.False(logger.IsEnabled(LogLevel.Information));
       Assert.False(logger.IsEnabled(LogLevel.Error));
+
+      // Positive control: the configured "specific" category IS enabled on the same provider,
+      // proving "unknown" is disabled by config resolution, not a trivially broken provider.
+      var known = provider.CreateLogger("specific");
+      Assert.True(known.IsEnabled(LogLevel.Debug));
+      Assert.False(known.IsEnabled(LogLevel.Trace));
     }
 
     /// <summary>
@@ -96,12 +110,14 @@ namespace Logfmt.Tests
       monitor.Set(lowered);
 
       Assert.True(logger.IsEnabled(LogLevel.Debug));
+      Assert.False(logger.IsEnabled(LogLevel.Trace));
 
       var raised = new ExtensionLoggerConfiguration();
       raised.LogLevel["Default"] = LogLevel.Error;
       monitor.Set(raised);
 
       Assert.False(logger.IsEnabled(LogLevel.Debug));
+      Assert.False(logger.IsEnabled(LogLevel.Warning));
       Assert.True(logger.IsEnabled(LogLevel.Error));
     }
 
@@ -138,6 +154,7 @@ namespace Logfmt.Tests
       var logger = provider.CreateLogger("mycategory");
 
       Assert.True(logger.IsEnabled(LogLevel.Debug));
+      Assert.False(logger.IsEnabled(LogLevel.Trace));
     }
 
     /// <summary>

--- a/Logfmt.Tests/ExtensionLoggerConfigurationTests.cs
+++ b/Logfmt.Tests/ExtensionLoggerConfigurationTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Ken Haines. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Logfmt.Tests
+{
+  using System;
+  using System.Collections.Generic;
+  using Logfmt.ExtensionLogging;
+  using Microsoft.Extensions.Logging;
+  using Xunit;
+
+  /// <summary>
+  /// Tests covering configuration scenarios for the Logfmt.ExtensionLogging provider.
+  /// </summary>
+  public class ExtensionLoggerConfigurationTests
+  {
+    /// <summary>
+    /// Tests that an empty configuration disables logging for a specific category.
+    /// </summary>
+    [Fact]
+    public void EmptyConfigWithSpecificCategoryDisablesLogging()
+    {
+      var monitor = new ChangeableOptionsMonitor(new ExtensionLoggerConfiguration());
+      using var provider = new ExtensionLoggerProvider(monitor);
+      var logger = provider.CreateLogger("SomeCategory");
+
+      Assert.False(logger.IsEnabled(LogLevel.Information));
+      Assert.False(logger.IsEnabled(LogLevel.Error));
+    }
+
+    /// <summary>
+    /// Tests that assigning the same category twice keeps the last value.
+    /// </summary>
+    [Fact]
+    public void DuplicateCategoryAssignmentLastWins()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["cat"] = LogLevel.Warning;
+      config.LogLevel["cat"] = LogLevel.Debug;
+      var monitor = new ChangeableOptionsMonitor(config);
+      using var provider = new ExtensionLoggerProvider(monitor);
+      var logger = provider.CreateLogger("cat");
+
+      Assert.True(logger.IsEnabled(LogLevel.Debug));
+    }
+
+    /// <summary>
+    /// Tests that the Default category level is used when a specific category is not configured.
+    /// </summary>
+    [Fact]
+    public void DefaultCategoryUsedWhenSpecificMissing()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["Default"] = LogLevel.Information;
+      var monitor = new ChangeableOptionsMonitor(config);
+      using var provider = new ExtensionLoggerProvider(monitor);
+      var logger = provider.CreateLogger("unconfigured");
+
+      Assert.True(logger.IsEnabled(LogLevel.Information));
+      Assert.True(logger.IsEnabled(LogLevel.Warning));
+      Assert.False(logger.IsEnabled(LogLevel.Debug));
+    }
+
+    /// <summary>
+    /// Tests that an unknown category with no Default configured is disabled.
+    /// </summary>
+    [Fact]
+    public void UnknownCategoryWithoutDefaultIsDisabled()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["specific"] = LogLevel.Debug;
+      var monitor = new ChangeableOptionsMonitor(config);
+      using var provider = new ExtensionLoggerProvider(monitor);
+      var logger = provider.CreateLogger("unknown");
+
+      Assert.False(logger.IsEnabled(LogLevel.Information));
+      Assert.False(logger.IsEnabled(LogLevel.Error));
+    }
+
+    /// <summary>
+    /// Tests that a runtime configuration change through the options monitor is reflected by IsEnabled.
+    /// </summary>
+    [Fact]
+    public void RuntimeLevelChangeReflectedInIsEnabled()
+    {
+      var initial = new ExtensionLoggerConfiguration();
+      initial.LogLevel["Default"] = LogLevel.Warning;
+      var monitor = new ChangeableOptionsMonitor(initial);
+      using var provider = new ExtensionLoggerProvider(monitor);
+      var logger = provider.CreateLogger("cat");
+
+      Assert.False(logger.IsEnabled(LogLevel.Debug));
+
+      var lowered = new ExtensionLoggerConfiguration();
+      lowered.LogLevel["Default"] = LogLevel.Debug;
+      monitor.Set(lowered);
+
+      Assert.True(logger.IsEnabled(LogLevel.Debug));
+
+      var raised = new ExtensionLoggerConfiguration();
+      raised.LogLevel["Default"] = LogLevel.Error;
+      monitor.Set(raised);
+
+      Assert.False(logger.IsEnabled(LogLevel.Debug));
+      Assert.True(logger.IsEnabled(LogLevel.Error));
+    }
+
+    /// <summary>
+    /// Tests that resetting the configuration to empty at runtime disables a previously enabled category.
+    /// </summary>
+    [Fact]
+    public void RuntimeConfigResetDisablesCategory()
+    {
+      var initial = new ExtensionLoggerConfiguration();
+      initial.LogLevel["Default"] = LogLevel.Information;
+      var monitor = new ChangeableOptionsMonitor(initial);
+      using var provider = new ExtensionLoggerProvider(monitor);
+      var logger = provider.CreateLogger("cat");
+
+      Assert.True(logger.IsEnabled(LogLevel.Information));
+
+      monitor.Set(new ExtensionLoggerConfiguration());
+
+      Assert.False(logger.IsEnabled(LogLevel.Information));
+    }
+
+    /// <summary>
+    /// Tests that category matching is case-insensitive, consistent with the provider's case-insensitive logger cache.
+    /// </summary>
+    [Fact]
+    public void CategoryMatchingIsCaseInsensitive()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["MyCategory"] = LogLevel.Debug;
+      var monitor = new ChangeableOptionsMonitor(config);
+      using var provider = new ExtensionLoggerProvider(monitor);
+
+      var logger = provider.CreateLogger("mycategory");
+
+      Assert.True(logger.IsEnabled(LogLevel.Debug));
+    }
+
+    /// <summary>
+    /// An <see cref="Microsoft.Extensions.Options.IOptionsMonitor{TOptions}"/> whose value can be changed at runtime.
+    /// </summary>
+    private sealed class ChangeableOptionsMonitor : Microsoft.Extensions.Options.IOptionsMonitor<ExtensionLoggerConfiguration>
+    {
+#nullable enable
+      private readonly List<Action<ExtensionLoggerConfiguration, string?>> listeners = new List<Action<ExtensionLoggerConfiguration, string?>>();
+
+      public ChangeableOptionsMonitor(ExtensionLoggerConfiguration value)
+      {
+        this.CurrentValue = value;
+      }
+
+      public ExtensionLoggerConfiguration CurrentValue { get; private set; }
+
+      public ExtensionLoggerConfiguration Get(string? name)
+      {
+        return this.CurrentValue;
+      }
+
+      public IDisposable? OnChange(Action<ExtensionLoggerConfiguration, string?> listener)
+      {
+        this.listeners.Add(listener);
+        return new Unsubscriber();
+      }
+
+      public void Set(ExtensionLoggerConfiguration value)
+      {
+        this.CurrentValue = value;
+        foreach (var listener in this.listeners)
+        {
+          listener(value, null);
+        }
+      }
+
+      private sealed class Unsubscriber : IDisposable
+      {
+        public void Dispose()
+        {
+        }
+      }
+#nullable restore
+    }
+  }
+}

--- a/Logfmt/ExtensionLogging/ExtensionLoggerConfiguration.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLoggerConfiguration.cs
@@ -12,8 +12,9 @@ using Microsoft.Extensions.Logging;
 public class ExtensionLoggerConfiguration
 {
     /// <summary>
-    /// Gets the dictionary of log levels keyed by category name.
+    /// Gets the dictionary of log levels keyed by category name. Category matching is case-insensitive,
+    /// consistent with the provider's case-insensitive logger cache.
     /// Use "Default" as the key to set the fallback log level.
     /// </summary>
-    public Dictionary<string, LogLevel> LogLevel { get; } = new Dictionary<string, LogLevel>();
+    public Dictionary<string, LogLevel> LogLevel { get; } = new Dictionary<string, LogLevel>(StringComparer.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
Closes #59.

## What
Adds a configuration test suite for the M.E.Logging provider and fixes a category-matching inconsistency.

### Tests added (7) — new file `ExtensionLoggerConfigurationTests.cs`
- Empty config disables a specific category
- Duplicate category assignment — last value wins
- `Default` fallback used when a specific category is missing
- Unknown category with no `Default` is disabled
- **Runtime level change** via `IOptionsMonitor` is reflected by `IsEnabled` (raise and lower)
- **Runtime config reset** to empty disables a previously enabled category
- **Case-insensitive** category matching

The suite adds a `ChangeableOptionsMonitor` test helper that actually fires `OnChange` (the existing `TestOptionsMonitor.OnChange` returns `null`).

### Production change (bug fix)
The provider's logger cache is case-insensitive (`ConcurrentDictionary(StringComparer.OrdinalIgnoreCase)`), but `ExtensionLoggerConfiguration.LogLevel` was a **case-sensitive** `Dictionary`. So a level set as `"MyCategory"` was **not** matched for a logger created as `"mycategory"` — the category was silently disabled. `LogLevel` now uses `StringComparer.OrdinalIgnoreCase`, consistent with the cache.

## Deferred (follow-up #70)
A distinct, deeper issue found while testing: the provider bakes the config level into the **core `Logger`'s filter at creation**, so **runtime level-lowering** doesn't fully take effect (the core `Logger` double-gates). It's awkward to test through the provider (stdout) and touches provider construction, so it's tracked in #70 rather than fixed here.

## Validation
- `dotnet test` green on **net8.0** and **net10.0**: 99/99 (92 baseline + 7 new)

## Note
New standalone test file — no overlap with the other in-flight test PRs.
