### PR TITLE
Add unicode handling tests (#61)

### DIFF
--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -172,6 +172,14 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
+      // Raw wire form: exact tokens for the space-free values, and the full quoted literal for the
+      // (always-quoted) msg, so a symmetric encode/decode transform cannot hide behind round-trip.
+      var tokens = output.Split(' ');
+      Assert.Contains("emoji=\U0001F44D\U0001F3FD", tokens);
+      Assert.Contains("accent=caf\u00e9", tokens);
+      Assert.Contains("cjk=\u65e5\u672c\u8a9e", tokens);
+      Assert.Contains("msg=\"\u4e2d\u6587 message \U0001F600\"", output);
+
       Assert.Equal("\u4e2d\u6587 message \U0001F600", dict["msg"]);
       Assert.Equal("\U0001F44D\U0001F3FD", dict["emoji"]);
       Assert.Equal("caf\u00e9", dict["accent"]);
@@ -199,6 +207,12 @@ namespace Logfmt.Tests
       string line;
       while ((line = reader.ReadLine()) != null)
       {
+        // Raw wire tokens (msg is always quoted) plus the parsed round-trip, per line.
+        var tokens = line.Split(' ');
+        Assert.Contains("msg=\"\u4e2d\u6587\"", tokens);
+        Assert.Contains("emoji=\U0001F600", tokens);
+        Assert.Contains($"seq={count}", tokens);
+
         var dict = ParseToDict(line);
         Assert.Equal("\u4e2d\u6587", dict["msg"]);
         Assert.Equal("\U0001F600", dict["emoji"]);
@@ -231,6 +245,10 @@ namespace Logfmt.Tests
 
         // Exactly one record: the unicode separator did not start a new line.
         Assert.Null(secondLine);
+
+        // The value (with the separator) is emitted verbatim as a single unquoted token, so a
+        // symmetric wire transform of the separator cannot hide behind the parser round-trip.
+        Assert.Contains("k=" + value, firstLine.Split(' '));
 
         // The separator is not a delimiter: the value stays intact in one field, with no forged key.
         var dict = ParseToDict(firstLine);

--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Ken Haines. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Logfmt.Tests
+{
+  using System.Collections.Generic;
+  using System.IO;
+  using Logfmt;
+  using Xunit;
+
+  /// <summary>
+  /// Tests covering unicode handling in keys and values across the Logger and LogfmtParser.
+  /// </summary>
+  public class UnicodeHandlingTests
+  {
+    /// <summary>
+    /// Tests that CJK characters in values pass through and round-trip.
+    /// </summary>
+    [Fact]
+    public void CjkCharactersInValuesRoundTrip()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      logger.Info("greeting", "zh", "\u4e2d\u6587", "ja", "\u3053\u3093\u306b\u3061\u306f", "ko", "\uc548\ub155\ud558\uc138\uc694");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
+
+      Assert.Equal("\u4e2d\u6587", dict["zh"]);
+      Assert.Equal("\u3053\u3093\u306b\u3061\u306f", dict["ja"]);
+      Assert.Equal("\uc548\ub155\ud558\uc138\uc694", dict["ko"]);
+    }
+
+    /// <summary>
+    /// Tests that an emoji with a skin-tone modifier round-trips in a value.
+    /// </summary>
+    [Fact]
+    public void EmojiWithSkinToneInValueRoundTrips()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      var emoji = "\U0001F44D\U0001F3FD";
+      logger.Info("react", "emoji", emoji);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
+
+      Assert.Equal(emoji, dict["emoji"]);
+    }
+
+    /// <summary>
+    /// Tests that combining diacritical marks round-trip in a value.
+    /// </summary>
+    [Fact]
+    public void CombiningDiacriticalMarksInValueRoundTrip()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      var combined = "e\u0301\u0302n\u0303";
+      logger.Info("m", "text", combined);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
+
+      Assert.Equal(combined, dict["text"]);
+    }
+
+    /// <summary>
+    /// Tests that surrogate pairs round-trip in a value.
+    /// </summary>
+    [Fact]
+    public void SurrogatePairsInValueRoundTrip()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      var surrogate = "\U0001F600\U00020BB7\U0001F680";
+      logger.Info("m", "chars", surrogate);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
+
+      Assert.Equal(surrogate, dict["chars"]);
+    }
+
+    /// <summary>
+    /// Tests that unicode characters in keys are converted to underscores by the Logger.
+    /// </summary>
+    [Fact]
+    public void UnicodeKeysAreConvertedToUnderscores()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      logger.Info("m", "user\u00e9", "v1", "\U0001F600key", "v2");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("user_=v1", output);
+      Assert.Contains("_key=v2", output);
+      Assert.DoesNotContain("\u00e9", output);
+      Assert.DoesNotContain("\U0001F600", output);
+    }
+
+    /// <summary>
+    /// Tests that the parser handles unicode values directly, both quoted and unquoted.
+    /// </summary>
+    [Fact]
+    public void ParserHandlesUnicodeValuesDirectly()
+    {
+      var dict = ParseToDict("emoji=\U0001F600 cjk=\u4e2d\u6587 quoted=\"caf\u00e9 \u4e2d\u6587\"");
+
+      Assert.Equal("\U0001F600", dict["emoji"]);
+      Assert.Equal("\u4e2d\u6587", dict["cjk"]);
+      Assert.Equal("caf\u00e9 \u4e2d\u6587", dict["quoted"]);
+    }
+
+    /// <summary>
+    /// Tests that a message and values combining several unicode categories round-trip through the logger and parser.
+    /// </summary>
+    [Fact]
+    public void MixedUnicodeRoundTripsThroughLoggerAndParser()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      logger.Info("\u4e2d\u6587 message \U0001F600", "emoji", "\U0001F44D\U0001F3FD", "accent", "caf\u00e9", "cjk", "\u65e5\u672c\u8a9e");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
+
+      Assert.Equal("\u4e2d\u6587 message \U0001F600", dict["msg"]);
+      Assert.Equal("\U0001F44D\U0001F3FD", dict["emoji"]);
+      Assert.Equal("caf\u00e9", dict["accent"]);
+      Assert.Equal("\u65e5\u672c\u8a9e", dict["cjk"]);
+    }
+
+    /// <summary>
+    /// Tests that logging unicode content in bulk produces correct output for every entry.
+    /// Real throughput measurement belongs to the benchmark suite.
+    /// </summary>
+    [Fact]
+    public void BulkUnicodeLoggingProducesCorrectOutput()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      for (int i = 0; i < 500; i++)
+      {
+        logger.Info("\u4e2d\u6587", "emoji", "\U0001F600");
+      }
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var reader = new StreamReader(outputStream);
+      var count = 0;
+      string line;
+      while ((line = reader.ReadLine()) != null)
+      {
+        var dict = ParseToDict(line);
+        Assert.Equal("\U0001F600", dict["emoji"]);
+        count++;
+      }
+
+      Assert.Equal(500, count);
+    }
+
+    private static Dictionary<string, string> ParseToDict(string line)
+    {
+      var dict = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(line))
+      {
+        dict[kvp.Key] = kvp.Value;
+      }
+
+      return dict;
+    }
+  }
+}

--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -114,9 +114,12 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
+      var tokens = output.Split(' ');
 
-      // Exact key names pin the sanitization (and its consecutive-underscore collapse), so a
-      // double-underscore ("__key") or value-corruption mutation cannot survive a Contains substring.
+      // Exact RAW tokens pin the on-wire key form (defeating a symmetric key-encoding transform)
+      // including the consecutive-underscore collapse; the parsed checks add the round-trip.
+      Assert.Contains("user_=v1", tokens);
+      Assert.Contains("_key=v2", tokens);
       Assert.Equal("v1", dict["user_"]);
       Assert.Equal("v2", dict["_key"]);
       Assert.False(dict.ContainsKey("user\u00e9"));
@@ -139,6 +142,8 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
+      // Exact RAW token pins the on-wire single-underscore key (defeats a symmetric key transform).
+      Assert.Contains("_=v", output.Split(' '));
       Assert.Equal("v", dict["_"]);
       Assert.False(dict.ContainsKey("\u4e2d\u6587"));
       Assert.DoesNotContain("\u4e2d", output);

--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -38,6 +38,7 @@ namespace Logfmt.Tests
       Assert.Equal("\u4e2d\u6587", dict["zh"]);
       Assert.Equal("\u3053\u3093\u306b\u3061\u306f", dict["ja"]);
       Assert.Equal("\uc548\ub155\ud558\uc138\uc694", dict["ko"]);
+      AssertFieldSet(output, "zh", "ja", "ko");
     }
 
     /// <summary>
@@ -58,6 +59,7 @@ namespace Logfmt.Tests
 
       Assert.Contains("emoji=" + emoji, output.Split(' '));
       Assert.Equal(emoji, dict["emoji"]);
+      AssertFieldSet(output, "emoji");
     }
 
     /// <summary>
@@ -78,6 +80,7 @@ namespace Logfmt.Tests
 
       Assert.Contains("text=" + combined, output.Split(' '));
       Assert.Equal(combined, dict["text"]);
+      AssertFieldSet(output, "text");
     }
 
     /// <summary>
@@ -98,6 +101,7 @@ namespace Logfmt.Tests
 
       Assert.Contains("chars=" + surrogate, output.Split(' '));
       Assert.Equal(surrogate, dict["chars"]);
+      AssertFieldSet(output, "chars");
     }
 
     /// <summary>
@@ -125,6 +129,7 @@ namespace Logfmt.Tests
       Assert.False(dict.ContainsKey("user\u00e9"));
       Assert.DoesNotContain("\u00e9", output);
       Assert.DoesNotContain("\U0001F600", output);
+      AssertFieldSet(output, "user_", "_key");
     }
 
     /// <summary>
@@ -147,6 +152,7 @@ namespace Logfmt.Tests
       Assert.Equal("v", dict["_"]);
       Assert.False(dict.ContainsKey("\u4e2d\u6587"));
       Assert.DoesNotContain("\u4e2d", output);
+      AssertFieldSet(output, "_");
     }
 
     /// <summary>
@@ -155,7 +161,11 @@ namespace Logfmt.Tests
     [Fact]
     public void ParserHandlesUnicodeValuesDirectly()
     {
-      var dict = ParseToDict("emoji=\U0001F600 cjk=\u4e2d\u6587 quoted=\"caf\u00e9 \u4e2d\u6587\"");
+      var input = "emoji=\U0001F600 cjk=\u4e2d\u6587 quoted=\"caf\u00e9 \u4e2d\u6587\"";
+      var pairs = LogfmtParser.Parse(input);
+      Assert.Equal(3, pairs.Count);
+
+      var dict = ParseToDict(input);
 
       Assert.Equal("\U0001F600", dict["emoji"]);
       Assert.Equal("\u4e2d\u6587", dict["cjk"]);
@@ -189,6 +199,7 @@ namespace Logfmt.Tests
       Assert.Equal("\U0001F44D\U0001F3FD", dict["emoji"]);
       Assert.Equal("caf\u00e9", dict["accent"]);
       Assert.Equal("\u65e5\u672c\u8a9e", dict["cjk"]);
+      AssertFieldSet(output, "emoji", "accent", "cjk");
     }
 
     /// <summary>
@@ -222,6 +233,7 @@ namespace Logfmt.Tests
         Assert.Equal("\u4e2d\u6587", dict["msg"]);
         Assert.Equal("\U0001F600", dict["emoji"]);
         Assert.Equal($"{count}", dict["seq"]);
+        AssertFieldSet(line, "emoji", "seq");
         count++;
       }
 
@@ -259,6 +271,26 @@ namespace Logfmt.Tests
         var dict = ParseToDict(firstLine);
         Assert.Equal(value, dict["k"]);
         Assert.False(dict.ContainsKey("injected"));
+        AssertFieldSet(firstLine, "k");
+      }
+    }
+
+    private static void AssertFieldSet(string line, params string[] dataKeys)
+    {
+      var keys = new List<string>();
+      foreach (var kvp in LogfmtParser.Parse(line))
+      {
+        keys.Add(kvp.Key);
+      }
+
+      var expected = new List<string> { "ts", "level", "msg" };
+      expected.AddRange(dataKeys);
+
+      // Exactly these fields, each exactly once: catches dropped, duplicated, or leaked fields.
+      Assert.Equal(expected.Count, keys.Count);
+      foreach (var key in expected)
+      {
+        Assert.Single(keys, k => k == key);
       }
     }
 

--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -28,8 +28,12 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
-      // Raw wire form is verbatim, so a symmetric encode/decode bug cannot hide behind round-trip.
-      Assert.Contains("zh=\u4e2d\u6587", output);
+      // Raw wire form is verbatim (exact space-delimited tokens), so a symmetric encode/decode
+      // transform -- even a suffix -- cannot hide behind the round-trip.
+      var tokens = output.Split(' ');
+      Assert.Contains("zh=\u4e2d\u6587", tokens);
+      Assert.Contains("ja=\u3053\u3093\u306b\u3061\u306f", tokens);
+      Assert.Contains("ko=\uc548\ub155\ud558\uc138\uc694", tokens);
 
       Assert.Equal("\u4e2d\u6587", dict["zh"]);
       Assert.Equal("\u3053\u3093\u306b\u3061\u306f", dict["ja"]);
@@ -52,7 +56,7 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
-      Assert.Contains("emoji=" + emoji, output);
+      Assert.Contains("emoji=" + emoji, output.Split(' '));
       Assert.Equal(emoji, dict["emoji"]);
     }
 
@@ -72,7 +76,7 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
-      Assert.Contains("text=" + combined, output);
+      Assert.Contains("text=" + combined, output.Split(' '));
       Assert.Equal(combined, dict["text"]);
     }
 
@@ -92,7 +96,7 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
-      Assert.Contains("chars=" + surrogate, output);
+      Assert.Contains("chars=" + surrogate, output.Split(' '));
       Assert.Equal(surrogate, dict["chars"]);
     }
 

--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -28,6 +28,9 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
+      // Raw wire form is verbatim, so a symmetric encode/decode bug cannot hide behind round-trip.
+      Assert.Contains("zh=\u4e2d\u6587", output);
+
       Assert.Equal("\u4e2d\u6587", dict["zh"]);
       Assert.Equal("\u3053\u3093\u306b\u3061\u306f", dict["ja"]);
       Assert.Equal("\uc548\ub155\ud558\uc138\uc694", dict["ko"]);
@@ -49,6 +52,7 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
+      Assert.Contains("emoji=" + emoji, output);
       Assert.Equal(emoji, dict["emoji"]);
     }
 
@@ -68,6 +72,7 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
+      Assert.Contains("text=" + combined, output);
       Assert.Equal(combined, dict["text"]);
     }
 
@@ -87,6 +92,7 @@ namespace Logfmt.Tests
       var output = new StreamReader(outputStream).ReadLine();
       var dict = ParseToDict(output);
 
+      Assert.Contains("chars=" + surrogate, output);
       Assert.Equal(surrogate, dict["chars"]);
     }
 
@@ -103,11 +109,35 @@ namespace Logfmt.Tests
 
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
 
-      Assert.Contains("user_=v1", output);
-      Assert.Contains("_key=v2", output);
+      // Exact key names pin the sanitization (and its consecutive-underscore collapse), so a
+      // double-underscore ("__key") or value-corruption mutation cannot survive a Contains substring.
+      Assert.Equal("v1", dict["user_"]);
+      Assert.Equal("v2", dict["_key"]);
+      Assert.False(dict.ContainsKey("user\u00e9"));
       Assert.DoesNotContain("\u00e9", output);
       Assert.DoesNotContain("\U0001F600", output);
+    }
+
+    /// <summary>
+    /// Tests that a key consisting entirely of unicode collapses to a single underscore.
+    /// </summary>
+    [Fact]
+    public void FullyUnicodeKeyIsConvertedToSingleUnderscore()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      logger.Info("m", "\u4e2d\u6587", "v");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
+
+      Assert.Equal("v", dict["_"]);
+      Assert.False(dict.ContainsKey("\u4e2d\u6587"));
+      Assert.DoesNotContain("\u4e2d", output);
     }
 
     /// <summary>
@@ -156,7 +186,7 @@ namespace Logfmt.Tests
 
       for (int i = 0; i < 500; i++)
       {
-        logger.Info("\u4e2d\u6587", "emoji", "\U0001F600");
+        logger.Info("\u4e2d\u6587", "emoji", "\U0001F600", "seq", $"{i}");
       }
 
       outputStream.Seek(0, SeekOrigin.Begin);
@@ -166,11 +196,43 @@ namespace Logfmt.Tests
       while ((line = reader.ReadLine()) != null)
       {
         var dict = ParseToDict(line);
+        Assert.Equal("\u4e2d\u6587", dict["msg"]);
         Assert.Equal("\U0001F600", dict["emoji"]);
+        Assert.Equal($"{count}", dict["seq"]);
         count++;
       }
 
       Assert.Equal(500, count);
+    }
+
+    /// <summary>
+    /// Tests that unicode pseudo-separators in a value cannot break the record boundary or inject a
+    /// forged field, because the logfmt encoder and parser only treat ASCII whitespace as a delimiter.
+    /// </summary>
+    [Fact]
+    public void UnicodeSeparatorsInValueDoNotBreakRecordOrInjectField()
+    {
+      foreach (var separator in new[] { "\u2028", "\u2029", "\u0085", "\u00a0", "\u2003" })
+      {
+        var outputStream = new MemoryStream();
+        using var logger = new Logger(outputStream);
+
+        var value = "a" + separator + "injected=evil";
+        logger.Info("m", "k", value);
+
+        outputStream.Seek(0, SeekOrigin.Begin);
+        var reader = new StreamReader(outputStream);
+        var firstLine = reader.ReadLine();
+        var secondLine = reader.ReadLine();
+
+        // Exactly one record: the unicode separator did not start a new line.
+        Assert.Null(secondLine);
+
+        // The separator is not a delimiter: the value stays intact in one field, with no forged key.
+        var dict = ParseToDict(firstLine);
+        Assert.Equal(value, dict["k"]);
+        Assert.False(dict.ContainsKey("injected"));
+      }
     }
 
     private static Dictionary<string, string> ParseToDict(string line)


### PR DESCRIPTION
Closes #61.

## What
Adds a dedicated unicode-handling test suite (`UnicodeHandlingTests.cs`) spanning the `Logger` and `LogfmtParser`. **Test-only** — values pass through unchanged and keys are already sanitized to `[A-Za-z0-9_]`.

### Tests added (10)
- **CJK** (Chinese/Japanese/Korean) characters in values round-trip **and** are asserted verbatim on the wire
- **Emoji with skin-tone** modifier round-trips (verbatim on the wire)
- **Combining diacritical marks** round-trip (verbatim on the wire)
- **Surrogate pairs** round-trip (verbatim on the wire)
- **Unicode keys** are sanitized to underscores by the Logger, asserted by **exact parsed key name** (`user_`, `_key`), with the é/emoji absent from output
- **Fully-unicode key** (e.g. `中文`) collapses to a **single** underscore
- **Parser** handles unicode directly (quoted and unquoted)
- **Mixed** unicode message + values round-trip through Logger → Parser
- **Bulk** unicode logging (500 entries) verifies the msg, emoji, **and** a per-iteration sequence value for every line
- **Unicode pseudo-separators** (U+2028/U+2029/U+0085/U+00A0/U+2003) in a value do **not** break the record boundary or inject a forged field (single record; value intact; no injected key)

Round-trip tests are backed by raw on-wire assertions so a symmetric encode/decode bug cannot hide.

## Acceptance-criteria disposition (#61)
| # | Criterion | Disposition |
|---|-----------|-------------|
| 1 | CJK characters | ✅ Covered (round-trip + raw wire) |
| 2 | Emoji sequences with skin tones | ✅ Covered (round-trip + raw wire) |
| 3 | Combining diacritical marks | ✅ Covered (round-trip + raw wire) |
| 4 | Surrogate pairs in values | ✅ Covered (round-trip + raw wire) |
| 5 | Unicode keys escaped/converted | ✅ Covered (exact parsed key + fully-unicode key) |
| 6 | Parser round-trip for all scenarios | ✅ Covered |
| 7 | Performance impact of unicode handling | ⏭️ Deferred → #78 (benchmark scope; overlaps #60). Correctness at volume covered by the bulk test |

## Validation
- `dotnet test` green on **net8.0** and **net10.0**: 102/102; StyleCop clean (warnings-as-errors).

## Notes
- Standalone test file — no overlap with the other in-flight test PRs.
- The encoder/parser are injection-safe for the logfmt format (record/field/key boundaries hold under every unicode input); the new separator test guards that property against regression.
