### PR TITLE
Add real-world integration scenario tests (#62)

### DIFF
--- a/Logfmt.Tests/IntegrationScenarioTests.cs
+++ b/Logfmt.Tests/IntegrationScenarioTests.cs
@@ -39,11 +39,13 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
 
-      Assert.Contains("level=info", output);
-      Assert.Contains("Method=GET", output);
-      Assert.Contains("Path=/api/users", output);
-      Assert.Contains("StatusCode=200", output);
-      Assert.Contains("Elapsed=12", output);
+      var dict = ParseToDict(output);
+
+      Assert.Equal("info", dict["level"]);
+      Assert.Equal("GET", dict["Method"]);
+      Assert.Equal("/api/users", dict["Path"]);
+      Assert.Equal("200", dict["StatusCode"]);
+      Assert.Equal("12", dict["Elapsed"]);
     }
 
     /// <summary>
@@ -78,9 +80,14 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
 
-      Assert.Contains("level=error", output);
+      var dict = ParseToDict(output);
+
+      Assert.Equal("error", dict["level"]);
+      Assert.Equal("payment gateway timeout", dict["exception_msg"]);
+      Assert.Equal("4567", dict["OrderId"]);
+
+      // The spaced exception message is quoted verbatim on the wire (defeats symmetric masking).
       Assert.Contains("exception_msg=\"payment gateway timeout\"", output);
-      Assert.Contains("OrderId=4567", output);
     }
 
     /// <summary>
@@ -119,8 +126,12 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
 
-      Assert.Contains("trace_id=", output);
-      Assert.Contains("span_id=", output);
+      var dict = ParseToDict(output);
+
+      // trace_id/span_id must be present with valid non-empty W3C hex ids -- not merely "trace_id="
+      // (a bare-key assertion would pass even if the ids were dropped/empty).
+      Assert.Matches("^[0-9a-f]{32}$", dict["trace_id"]);
+      Assert.Matches("^[0-9a-f]{16}$", dict["span_id"]);
     }
 
     /// <summary>
@@ -137,10 +148,12 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
 
-      Assert.Contains("metric=http_requests_total", output);
-      Assert.Contains("value=1024", output);
-      Assert.Contains("unit=count", output);
-      Assert.Contains("endpoint=/api/orders", output);
+      var dict = ParseToDict(output);
+
+      Assert.Equal("http_requests_total", dict["metric"]);
+      Assert.Equal("1024", dict["value"]);
+      Assert.Equal("count", dict["unit"]);
+      Assert.Equal("/api/orders", dict["endpoint"]);
     }
 
     /// <summary>
@@ -163,6 +176,9 @@ namespace Logfmt.Tests
       Assert.Equal("/vault/secret-1", dict["resource"]);
       Assert.Equal("denied", dict["outcome"]);
       Assert.Equal("insufficient permissions", dict["reason"]);
+
+      // The spaced value is quoted verbatim on the wire, not split into a forged field.
+      Assert.Contains("reason=\"insufficient permissions\"", output);
     }
 
     /// <summary>
@@ -192,9 +208,28 @@ namespace Logfmt.Tests
       }
 
       Assert.Equal(4, lines.Count);
-      Assert.Contains(lines, l => l.Contains("source=auth") && l.Contains("user=alice"));
-      Assert.Contains(lines, l => l.Contains("source=db") && l.Contains("rows=42"));
-      Assert.Contains(lines, l => l.Contains("source=api") && l.Contains("status=200"));
+
+      // Order is deterministic (sequential writes to one stream); assert each record exactly,
+      // including the final auth "logout" line the substring checks previously skipped.
+      var login = ParseToDict(lines[0]);
+      Assert.Equal("auth", login["source"]);
+      Assert.Equal("alice", login["user"]);
+      Assert.Equal("login ok", login["msg"]);
+
+      var query = ParseToDict(lines[1]);
+      Assert.Equal("db", query["source"]);
+      Assert.Equal("42", query["rows"]);
+      Assert.Equal("query executed", query["msg"]);
+
+      var request = ParseToDict(lines[2]);
+      Assert.Equal("api", request["source"]);
+      Assert.Equal("200", request["status"]);
+      Assert.Equal("request served", request["msg"]);
+
+      var logout = ParseToDict(lines[3]);
+      Assert.Equal("auth", logout["source"]);
+      Assert.Equal("alice", logout["user"]);
+      Assert.Equal("logout", logout["msg"]);
     }
 
     private static ExtensionLoggerConfiguration AllEnabledConfig()

--- a/Logfmt.Tests/IntegrationScenarioTests.cs
+++ b/Logfmt.Tests/IntegrationScenarioTests.cs
@@ -46,6 +46,7 @@ namespace Logfmt.Tests
       Assert.Equal("/api/users", dict["Path"]);
       Assert.Equal("200", dict["StatusCode"]);
       Assert.Equal("12", dict["Elapsed"]);
+      AssertKeys(output, "ts", "level", "msg", "Method", "Path", "StatusCode", "Elapsed", "_OriginalFormat_");
     }
 
     /// <summary>
@@ -88,6 +89,7 @@ namespace Logfmt.Tests
 
       // The spaced exception message is quoted verbatim on the wire (defeats symmetric masking).
       Assert.Contains("exception_msg=\"payment gateway timeout\"", output);
+      AssertKeys(output, "ts", "level", "msg", "exception_msg", "exception_stack", "category", "OrderId", "_OriginalFormat_");
     }
 
     /// <summary>
@@ -118,20 +120,22 @@ namespace Logfmt.Tests
 
       var logger = loggerFactory.CreateLogger("Traced");
 
-      using (source.StartActivity("request"))
-      {
-        logger.LogInformation("handled request");
-      }
+      using var activity = source.StartActivity("request");
+      logger.LogInformation("handled request");
 
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
-
       var dict = ParseToDict(output);
 
-      // trace_id/span_id must be present with valid non-empty W3C hex ids -- not merely "trace_id="
-      // (a bare-key assertion would pass even if the ids were dropped/empty).
+      Assert.NotNull(activity);
+
+      // The exported ids must equal the active Activity's real (non-zero) W3C ids -- an all-zero or
+      // dropped id would still satisfy a length regex, so assert exact equality with the Activity.
+      Assert.Equal(activity!.TraceId.ToString(), dict["trace_id"]);
+      Assert.Equal(activity!.SpanId.ToString(), dict["span_id"]);
       Assert.Matches("^[0-9a-f]{32}$", dict["trace_id"]);
       Assert.Matches("^[0-9a-f]{16}$", dict["span_id"]);
+      AssertKeys(output, "ts", "level", "msg", "category", "trace_id", "span_id", "trace_flags", "_OriginalFormat_");
     }
 
     /// <summary>
@@ -154,6 +158,7 @@ namespace Logfmt.Tests
       Assert.Equal("1024", dict["value"]);
       Assert.Equal("count", dict["unit"]);
       Assert.Equal("/api/orders", dict["endpoint"]);
+      AssertKeys(output, "ts", "level", "msg", "metric", "value", "unit", "endpoint");
     }
 
     /// <summary>
@@ -165,20 +170,34 @@ namespace Logfmt.Tests
       var outputStream = new MemoryStream();
       using var logger = new Logger(outputStream);
 
-      logger.Info("audit event", "actor", "user:alice", "action", "DELETE", "resource", "/vault/secret-1", "outcome", "denied", "reason", "insufficient permissions");
+      // An adversarial audit value with a space, '=', a quote, and a newline must round-trip as a
+      // single field and cannot forge a field or split the record.
+      var reason = "insufficient permissions; token=\"abc\"\nlevel=fatal owned=1";
+      logger.Info("audit event", "actor", "user:alice", "action", "DELETE", "resource", "/vault/secret-1", "outcome", "denied", "reason", reason);
 
       outputStream.Seek(0, SeekOrigin.Begin);
-      var output = new StreamReader(outputStream).ReadLine();
+      var reader = new StreamReader(outputStream);
+      var output = reader.ReadLine();
+      var secondLine = reader.ReadLine();
+
+      // Exactly one physical record: the embedded newline is escaped, not emitted raw.
+      Assert.Null(secondLine);
+
       var dict = ParseToDict(output);
 
       Assert.Equal("user:alice", dict["actor"]);
       Assert.Equal("DELETE", dict["action"]);
       Assert.Equal("/vault/secret-1", dict["resource"]);
       Assert.Equal("denied", dict["outcome"]);
-      Assert.Equal("insufficient permissions", dict["reason"]);
+      Assert.Equal(reason, dict["reason"]);
 
-      // The spaced value is quoted verbatim on the wire, not split into a forged field.
-      Assert.Contains("reason=\"insufficient permissions\"", output);
+      // The injection payload forged no field and left the real level unchanged.
+      Assert.False(dict.ContainsKey("owned"));
+      Assert.Equal("info", dict["level"]);
+
+      // The embedded quote is escaped on the wire (proving the value cannot break out of its field).
+      Assert.Contains("token=\\\"abc\\\"", output);
+      AssertKeys(output, "ts", "level", "msg", "actor", "action", "resource", "outcome", "reason");
     }
 
     /// <summary>
@@ -215,21 +234,25 @@ namespace Logfmt.Tests
       Assert.Equal("auth", login["source"]);
       Assert.Equal("alice", login["user"]);
       Assert.Equal("login ok", login["msg"]);
+      AssertKeys(lines[0], "ts", "level", "msg", "user", "source");
 
       var query = ParseToDict(lines[1]);
       Assert.Equal("db", query["source"]);
       Assert.Equal("42", query["rows"]);
       Assert.Equal("query executed", query["msg"]);
+      AssertKeys(lines[1], "ts", "level", "msg", "rows", "source");
 
       var request = ParseToDict(lines[2]);
       Assert.Equal("api", request["source"]);
       Assert.Equal("200", request["status"]);
       Assert.Equal("request served", request["msg"]);
+      AssertKeys(lines[2], "ts", "level", "msg", "status", "source");
 
       var logout = ParseToDict(lines[3]);
       Assert.Equal("auth", logout["source"]);
       Assert.Equal("alice", logout["user"]);
       Assert.Equal("logout", logout["msg"]);
+      AssertKeys(lines[3], "ts", "level", "msg", "user", "source");
     }
 
     private static ExtensionLoggerConfiguration AllEnabledConfig()
@@ -248,6 +271,22 @@ namespace Logfmt.Tests
       }
 
       return dict;
+    }
+
+    private static void AssertKeys(string line, params string[] expectedKeys)
+    {
+      var keys = new List<string>();
+      foreach (var kvp in LogfmtParser.Parse(line))
+      {
+        keys.Add(kvp.Key);
+      }
+
+      // Exactly the expected fields, each exactly once: catches dropped, duplicated, or leaked fields.
+      Assert.Equal(expectedKeys.Length, keys.Count);
+      foreach (var key in expectedKeys)
+      {
+        Assert.Single(keys, k => k == key);
+      }
     }
   }
 }

--- a/Logfmt.Tests/IntegrationScenarioTests.cs
+++ b/Logfmt.Tests/IntegrationScenarioTests.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Ken Haines. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Logfmt.Tests
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Diagnostics;
+  using System.IO;
+  using Logfmt;
+  using Logfmt.ExtensionLogging;
+  using Logfmt.OpenTelemetryLogging;
+  using Microsoft.Extensions.Logging;
+  using OpenTelemetry;
+  using OpenTelemetry.Logs;
+  using Xunit;
+
+  /// <summary>
+  /// Integration tests exercising real-world logging scenarios through the supported
+  /// Microsoft.Extensions.Logging and OpenTelemetry entry points.
+  /// </summary>
+  /// <remarks>
+  /// Serilog and NLog scenarios are intentionally out of scope: this library provides
+  /// Microsoft.Extensions.Logging and OpenTelemetry integrations only, with no Serilog or NLog adapter.
+  /// </remarks>
+  public class IntegrationScenarioTests
+  {
+    /// <summary>
+    /// Tests an ASP.NET Core-style request completion log with structured route data.
+    /// </summary>
+    [Fact]
+    public void AspNetCoreStyleRequestLoggingProducesStructuredOutput()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), AllEnabledConfig, "Microsoft.AspNetCore.Hosting");
+
+      logger.LogInformation("Request finished {Method} {Path} {StatusCode} in {Elapsed}ms", "GET", "/api/users", 200, 12);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("level=info", output);
+      Assert.Contains("Method=GET", output);
+      Assert.Contains("Path=/api/users", output);
+      Assert.Contains("StatusCode=200", output);
+      Assert.Contains("Elapsed=12", output);
+    }
+
+    /// <summary>
+    /// Tests a real application error scenario where an exception and context are exported through OpenTelemetry.
+    /// </summary>
+    [Fact]
+    public void RealApplicationErrorScenarioLogsExceptionViaOpenTelemetry()
+    {
+      var outputStream = new MemoryStream();
+      var customLogger = new Logger(outputStream);
+
+      using var loggerFactory = LoggerFactory.Create(builder =>
+      {
+        builder.AddOpenTelemetry(options =>
+        {
+          options.IncludeFormattedMessage = true;
+          options.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogExporter(customLogger)));
+        });
+      });
+
+      var logger = loggerFactory.CreateLogger("OrderService");
+
+      try
+      {
+        throw new InvalidOperationException("payment gateway timeout");
+      }
+      catch (InvalidOperationException ex)
+      {
+        logger.LogError(ex, "Failed to process order {OrderId}", 4567);
+      }
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("level=error", output);
+      Assert.Contains("exception_msg=\"payment gateway timeout\"", output);
+      Assert.Contains("OrderId=4567", output);
+    }
+
+    /// <summary>
+    /// Tests that distributed-tracing context (trace and span ids) is exported when logging within an activity.
+    /// </summary>
+    [Fact]
+    public void DistributedTracingContextIsExported()
+    {
+      var outputStream = new MemoryStream();
+      var customLogger = new Logger(outputStream);
+
+      using var listener = new ActivityListener
+      {
+        ShouldListenTo = _ => true,
+        Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+      };
+      ActivitySource.AddActivityListener(listener);
+
+      using var source = new ActivitySource("Logfmt.Tests.Integration");
+
+      using var loggerFactory = LoggerFactory.Create(builder =>
+      {
+        builder.AddOpenTelemetry(options =>
+        {
+          options.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogExporter(customLogger)));
+        });
+      });
+
+      var logger = loggerFactory.CreateLogger("Traced");
+
+      using (source.StartActivity("request"))
+      {
+        logger.LogInformation("handled request");
+      }
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("trace_id=", output);
+      Assert.Contains("span_id=", output);
+    }
+
+    /// <summary>
+    /// Tests logging metric-style structured data.
+    /// </summary>
+    [Fact]
+    public void MetricsStyleLoggingProducesStructuredOutput()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      logger.Info("metric recorded", "metric", "http_requests_total", "value", "1024", "unit", "count", "endpoint", "/api/orders");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("metric=http_requests_total", output);
+      Assert.Contains("value=1024", output);
+      Assert.Contains("unit=count", output);
+      Assert.Contains("endpoint=/api/orders", output);
+    }
+
+    /// <summary>
+    /// Tests a security-audit log format, including a spaced value that must be quoted and round-trip.
+    /// </summary>
+    [Fact]
+    public void SecurityAuditLoggingRoundTrips()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      logger.Info("audit event", "actor", "user:alice", "action", "DELETE", "resource", "/vault/secret-1", "outcome", "denied", "reason", "insufficient permissions");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var dict = ParseToDict(output);
+
+      Assert.Equal("user:alice", dict["actor"]);
+      Assert.Equal("DELETE", dict["action"]);
+      Assert.Equal("/vault/secret-1", dict["resource"]);
+      Assert.Equal("denied", dict["outcome"]);
+      Assert.Equal("insufficient permissions", dict["reason"]);
+    }
+
+    /// <summary>
+    /// Tests batch logging from multiple sources sharing a single output stream via WithData.
+    /// </summary>
+    [Fact]
+    public void BatchLoggingFromMultipleSourcesInterleavesOnOneStream()
+    {
+      var outputStream = new MemoryStream();
+      var baseLogger = new Logger(outputStream, SeverityLevel.Info);
+      var authLogger = baseLogger.WithData("source", "auth");
+      var dbLogger = baseLogger.WithData("source", "db");
+      var apiLogger = baseLogger.WithData("source", "api");
+
+      authLogger.Info("login ok", "user", "alice");
+      dbLogger.Info("query executed", "rows", "42");
+      apiLogger.Info("request served", "status", "200");
+      authLogger.Info("logout", "user", "alice");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var reader = new StreamReader(outputStream);
+      var lines = new List<string>();
+      string line;
+      while ((line = reader.ReadLine()) != null)
+      {
+        lines.Add(line);
+      }
+
+      Assert.Equal(4, lines.Count);
+      Assert.Contains(lines, l => l.Contains("source=auth") && l.Contains("user=alice"));
+      Assert.Contains(lines, l => l.Contains("source=db") && l.Contains("rows=42"));
+      Assert.Contains(lines, l => l.Contains("source=api") && l.Contains("status=200"));
+    }
+
+    private static ExtensionLoggerConfiguration AllEnabledConfig()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["Default"] = LogLevel.Trace;
+      return config;
+    }
+
+    private static Dictionary<string, string> ParseToDict(string line)
+    {
+      var dict = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(line))
+      {
+        dict[kvp.Key] = kvp.Value;
+      }
+
+      return dict;
+    }
+  }
+}


### PR DESCRIPTION
Part of #62 (delivers the six criteria that apply to this library's integrations; Serilog/NLog are tracked in #79, so #62 stays open until those adapters land).

## What
Adds an integration test suite (`IntegrationScenarioTests.cs`) exercising real-world logging scenarios through the library's supported entry points. **Test-only.**

### Scenarios added (6)
- **ASP.NET Core-style** request completion log with structured route data (`Method`/`Path`/`StatusCode`/`Elapsed`) via `Microsoft.Extensions.Logging` — asserted by exact parsed values
- **Real application error** — an exception plus context exported through **OpenTelemetry** (`exception_msg`, `OrderId`), exact values + raw-wire quoted message
- **Distributed tracing** — `trace_id`/`span_id` emitted inside an active `Activity`, asserted to be valid non-empty W3C hex ids (32/16 hex), not just present
- **Metrics-style** structured logging — exact parsed values
- **Security audit** log format — a spaced value that must be quoted, asserted by exact parsed value + raw-wire form
- **Batch logging from multiple sources** — four `WithData`-derived loggers on one stream, each of the four records asserted exactly by index

Output is captured by injecting a `MemoryStream`-backed `Logger` into `ConsoleLogExporter` (OTel scenarios) or constructing `ExtensionLogger` directly (MEL scenarios).

## Acceptance-criteria disposition (#62)
| # | Criterion | Disposition |
|---|-----------|-------------|
| 1 | ASP.NET Core integration scenario | ✅ Covered |
| 2 | Serilog integration compatibility | ⏭️ Deferred → #79 (no Serilog adapter exists; building one is a separate feature) |
| 3 | NLog integration (if applicable) | ⏭️ Deferred → #79 (no NLog adapter exists) |
| 4 | Real application error scenarios | ✅ Covered (OpenTelemetry export) |
| 5 | Distributed tracing log formats | ✅ Covered (valid hex trace/span ids) |
| 6 | Metrics collection logs | ✅ Covered |
| 7 | Security audit log formats | ✅ Covered (quoted value round-trip + raw wire) |
| 8 | Batch logging from multiple sources | ✅ Covered (all four records asserted) |

## Descoped / Deferred
- **Serilog** and **NLog** — this library provides Microsoft.Extensions.Logging and OpenTelemetry integrations only; there is no Serilog or NLog adapter, so there is nothing to integration-test today. Tracked as a follow-up feature in **#79**.

## Validation
- `dotnet test` green on **net8.0** and **net10.0**: 98/98; StyleCop clean (warnings-as-errors).

## Note
Standalone test file — no overlap with the other in-flight test PRs.
