### PR TITLE
Fix ExtensionLogger runtime level-lowering (#70) and null-key never-throw (#76)

### DIFF
--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -1053,6 +1053,28 @@ namespace Logfmt.Tests
       Assert.DoesNotContain("dropped", content);
     }
 
+    /// <summary>
+    /// Tests that LogLevel.None is never enabled and never emitted, even with an unfiltered (Trace)
+    /// core Logger and a permissive config -- the regression the #70 fix could otherwise expose.
+    /// </summary>
+    [Fact]
+    public void TestLogLevelNoneIsNeverEnabledOrEmitted()
+    {
+      var outputStream = new MemoryStream();
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["Default"] = LogLevel.Trace;
+
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Trace), () => config, "cat");
+
+      Assert.False(logger.IsEnabled(LogLevel.None));
+
+      logger.Log(LogLevel.None, new EventId(0), "state", null, (s, e) => "should not emit");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var content = new StreamReader(outputStream).ReadToEnd();
+      Assert.Empty(content);
+    }
+
     private ExtensionLoggerConfiguration GetConfiguration()
     {
       var config = new ExtensionLoggerConfiguration();

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -6,6 +6,7 @@ namespace Logfmt.Tests
   using System;
   using System.Collections.Generic;
   using System.IO;
+  using System.Reflection;
 
   using Logfmt.ExtensionLogging;
   using Microsoft.Extensions.Logging;
@@ -1075,11 +1076,103 @@ namespace Logfmt.Tests
       Assert.Empty(content);
     }
 
+    /// <summary>
+    /// Tests that <see cref="ExtensionLoggerProvider.CreateLogger"/> constructs each category's core
+    /// <see cref="Logger"/> unfiltered (<see cref="SeverityLevel.Trace"/>) regardless of the configured
+    /// level, so <see cref="ExtensionLogger.IsEnabled(LogLevel)"/> -- which reads the live config -- is
+    /// the single severity gate (#70). This guards the provider construction line directly: baking the
+    /// creation-time level into the core Logger (the pre-fix double-gate) would fail this test.
+    /// </summary>
+    [Fact]
+    public void TestProviderConstructsCoreLoggerUnfiltered()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["provider-cat"] = LogLevel.Warning;
+      using var provider = new ExtensionLoggerProvider(new TestOptionsMonitor(config));
+
+      var extensionLogger = provider.CreateLogger("provider-cat");
+
+      // The private core Logger is the only seam; there is no public accessor by design.
+      var coreLoggerField = typeof(ExtensionLogger).GetField("logger", BindingFlags.Instance | BindingFlags.NonPublic);
+      Assert.NotNull(coreLoggerField);
+      var coreLogger = Assert.IsType<Logger>(coreLoggerField!.GetValue(extensionLogger));
+
+      // The core Logger must admit Trace (unfiltered). If the provider baked the configured Warning
+      // level into the core Logger (the #70 double-gate bug), IsEnabled(Trace) would be false.
+      Assert.True(coreLogger.IsEnabled(SeverityLevel.Trace));
+    }
+
+    /// <summary>
+    /// Tests that an undefined/out-of-range LogLevel (e.g. (LogLevel)7, above None) is never enabled or
+    /// emitted, even with a configured category and an unfiltered (Trace) core Logger. Without the range
+    /// guard, (LogLevel)7 would satisfy "configuredLevel &lt;= 7" and emit a spurious level=off entry --
+    /// the same class of regression the #70 unfilter exposes for None.
+    /// </summary>
+    [Fact]
+    public void TestUndefinedLogLevelIsNeverEnabledOrEmitted()
+    {
+      var outputStream = new MemoryStream();
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["cat"] = LogLevel.None;
+
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Trace), () => config, "cat");
+
+      Assert.False(logger.IsEnabled((LogLevel)7));
+
+      logger.Log((LogLevel)7, new EventId(0), "state", null, (s, e) => "should not emit");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var content = new StreamReader(outputStream).ReadToEnd();
+      Assert.Empty(content);
+    }
+
+    /// <summary>
+    /// Tests that a state whose enumerator throws mid-iteration does not escape Log (never-throw
+    /// contract): the exception is contained, properties collected before the fault survive, and a
+    /// [STATE ERROR] marker plus the formatted message are still emitted (#76).
+    /// </summary>
+    [Fact]
+    public void TestThrowingStateEnumeratorDoesNotEscape()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var ex = Record.Exception(() =>
+        logger.Log(LogLevel.Information, new EventId(0), new ThrowingEnumerableState(), null, (s, e) => "survived"));
+
+      Assert.Null(ex);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      // The good pair emitted before the enumerator threw survives; the fault is recorded; the message
+      // is still written -- all without throwing.
+      Assert.Equal("value", fields["good"]);
+      Assert.Contains("STATE ERROR", fields["state_error"]);
+      Assert.Equal("survived", fields[Logger.MessageKey]);
+    }
+
     private ExtensionLoggerConfiguration GetConfiguration()
     {
       var config = new ExtensionLoggerConfiguration();
       config.LogLevel["test"] = LogLevel.Information;
       return config;
+    }
+
+    private sealed class ThrowingEnumerableState : IEnumerable<KeyValuePair<string, object>>
+    {
+      public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+      {
+        yield return new KeyValuePair<string, object>("good", "value");
+        throw new InvalidOperationException("enumerator failed");
+      }
+
+      System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 
     private sealed class Node

--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -972,6 +972,87 @@ namespace Logfmt.Tests
       Assert.NotNull(logger);
     }
 
+    /// <summary>
+    /// Tests that a state item with a null key does not throw (never-throw contract) and is skipped,
+    /// while sibling entries are still logged (#76).
+    /// </summary>
+    [Fact]
+    public void TestNullStateKeyIsSkippedWithoutThrowing()
+    {
+      var outputStream = new MemoryStream();
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Info), this.GetConfiguration, "test");
+
+      var state = new[]
+      {
+        new KeyValuePair<string, object>(null!, "orphan"),
+        new KeyValuePair<string, object>("good", "value"),
+      };
+
+      var ex = Record.Exception(() => logger.Log(LogLevel.Information, new EventId(0), state, null, (s, e) => "m"));
+
+      Assert.Null(ex);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      // The null-keyed item is dropped; the valid sibling survives.
+      Assert.Equal("value", fields["good"]);
+      Assert.DoesNotContain("orphan", output);
+    }
+
+    /// <summary>
+    /// Tests that lowering a category's level at runtime takes effect when the core Logger is
+    /// unfiltered (Trace) -- the wiring the fixed provider uses so ExtensionLogger.IsEnabled (which
+    /// reads the live config) is the single severity gate (#70).
+    /// </summary>
+    [Fact]
+    public void TestRuntimeLevelLoweringEmitsWithUnfilteredCoreLogger()
+    {
+      var outputStream = new MemoryStream();
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["Default"] = LogLevel.Warning;
+
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Trace), () => config, "cat");
+
+      logger.LogInformation("before");
+
+      config.LogLevel["Default"] = LogLevel.Debug;
+      logger.LogInformation("after");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var content = new StreamReader(outputStream).ReadToEnd();
+
+      Assert.DoesNotContain("before", content);
+      Assert.Contains("after", content);
+    }
+
+    /// <summary>
+    /// Documents the #70 double-gate the fix removes: a core Logger baked with a restrictive filter
+    /// drops a runtime-lowered entry even though IsEnabled permits it -- which is why the provider now
+    /// constructs the core Logger unfiltered (Trace).
+    /// </summary>
+    [Fact]
+    public void TestBakedCoreFilterDropsRuntimeLoweredEntry()
+    {
+      var outputStream = new MemoryStream();
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["Default"] = LogLevel.Debug;
+
+      ILogger logger = new ExtensionLogger(new Logger(outputStream, SeverityLevel.Warn), () => config, "cat");
+
+      Assert.True(logger.IsEnabled(LogLevel.Information));
+      logger.LogInformation("dropped");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var content = new StreamReader(outputStream).ReadToEnd();
+      Assert.DoesNotContain("dropped", content);
+    }
+
     private ExtensionLoggerConfiguration GetConfiguration()
     {
       var config = new ExtensionLoggerConfiguration();

--- a/Logfmt/ExtensionLogging/ExtensionLogger.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLogger.cs
@@ -30,10 +30,11 @@ public class ExtensionLogger : ILogger
     /// <inheritdoc/>
     public bool IsEnabled(LogLevel logLevel)
     {
-        // LogLevel.None means "no logging"; it must never be enabled or emitted. Guard it explicitly:
-        // the numeric comparison below would otherwise treat None (the max value) as enabled, and with
-        // the core Logger now unfiltered (#70) that would emit a spurious level=off entry.
-        if (logLevel == LogLevel.None)
+        // Only the defined logging levels (Trace..Critical) may ever be enabled. LogLevel.None and any
+        // undefined/out-of-range value (e.g. (LogLevel)7) map to SeverityLevel.Off and must never emit:
+        // the numeric comparison below would otherwise treat a value above a configured level as enabled,
+        // and with the core Logger now unfiltered (#70) that would emit a spurious level=off entry.
+        if (logLevel < LogLevel.Trace || logLevel > LogLevel.Critical)
         {
             return false;
         }
@@ -81,25 +82,35 @@ public class ExtensionLogger : ILogger
         var props = new Dictionary<string, string>(8);
         if (state is IEnumerable<KeyValuePair<string, object>> stateProperties)
         {
-            // add properties from the state object if it was a collection of pairs
-            foreach (var prop in stateProperties)
+            // A state enumerator (MoveNext/Current) can itself throw; enumerating must never let that
+            // escape the logging call (never-throw contract). Preserve whatever was collected before the
+            // fault and record a marker so the failure is visible rather than silent (#76).
+            try
             {
-                // Skip null keys (a Dictionary indexer would throw ArgumentNullException, breaking the
-                // never-throw contract) and null values. Reachable via a KeyValuePair[] state with a
-                // null key; MEL's own state types never admit one (#76).
-                if (prop.Key is null || prop.Value is null)
+                // add properties from the state object if it was a collection of pairs
+                foreach (var prop in stateProperties)
                 {
-                    continue;
-                }
+                    // Skip null keys (a Dictionary indexer would throw ArgumentNullException, breaking the
+                    // never-throw contract) and null values. Reachable via a KeyValuePair[] state with a
+                    // null key; MEL's own state types never admit one (#76).
+                    if (prop.Key is null || prop.Value is null)
+                    {
+                        continue;
+                    }
 
-                try
-                {
-                    props[prop.Key] = prop.Value.ToString() ?? string.Empty;
+                    try
+                    {
+                        props[prop.Key] = prop.Value.ToString() ?? string.Empty;
+                    }
+                    catch (Exception ex)
+                    {
+                        props[prop.Key] = $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
+                    }
                 }
-                catch (Exception ex)
-                {
-                    props[prop.Key] = $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
-                }
+            }
+            catch (Exception ex)
+            {
+                props["state_error"] = $"[STATE ERROR: {SafeExceptionMessage(ex)}]";
             }
         }
 

--- a/Logfmt/ExtensionLogging/ExtensionLogger.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLogger.cs
@@ -76,16 +76,21 @@ public class ExtensionLogger : ILogger
             // add properties from the state object if it was a collection of pairs
             foreach (var prop in stateProperties)
             {
-                if (prop.Value != null)
+                // Skip null keys (a Dictionary indexer would throw ArgumentNullException, breaking the
+                // never-throw contract) and null values. Reachable via a KeyValuePair[] state with a
+                // null key; MEL's own state types never admit one (#76).
+                if (prop.Key is null || prop.Value is null)
                 {
-                    try
-                    {
-                        props[prop.Key] = prop.Value.ToString() ?? string.Empty;
-                    }
-                    catch (Exception ex)
-                    {
-                        props[prop.Key] = $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
-                    }
+                    continue;
+                }
+
+                try
+                {
+                    props[prop.Key] = prop.Value.ToString() ?? string.Empty;
+                }
+                catch (Exception ex)
+                {
+                    props[prop.Key] = $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
                 }
             }
         }

--- a/Logfmt/ExtensionLogging/ExtensionLogger.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLogger.cs
@@ -30,6 +30,14 @@ public class ExtensionLogger : ILogger
     /// <inheritdoc/>
     public bool IsEnabled(LogLevel logLevel)
     {
+        // LogLevel.None means "no logging"; it must never be enabled or emitted. Guard it explicitly:
+        // the numeric comparison below would otherwise treat None (the max value) as enabled, and with
+        // the core Logger now unfiltered (#70) that would emit a spurious level=off entry.
+        if (logLevel == LogLevel.None)
+        {
+            return false;
+        }
+
         var config = getCurrentConfig();
         if (config.LogLevel.TryGetValue(this.categoryName, out var categoryLevel))
         {

--- a/Logfmt/ExtensionLogging/ExtensionLoggerProvider.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLoggerProvider.cs
@@ -41,15 +41,12 @@ public sealed class ExtensionLoggerProvider : ILoggerProvider
       Justification = "The created logger instance has a longer lifetime than the method it is created in.")]
     public ILogger CreateLogger(string categoryName)
     {
-        return _loggers.GetOrAdd(categoryName, name =>
-        {
-            if (!_currentConfig.LogLevel.TryGetValue(name, out LogLevel logLevel) && !_currentConfig.LogLevel.TryGetValue("Default", out logLevel))
-            {
-                logLevel = LogLevel.None;
-            }
-
-            return new ExtensionLogger(new Logger(logLevel.ToSeverityLevel()).WithData(Category, name), GetCurrentConfig, name);
-        });
+        // The core Logger is intentionally unfiltered (Trace): ExtensionLogger.IsEnabled reads the
+        // live configuration on every call and is the single severity gate. Baking the creation-time
+        // level into the core Logger would double-gate and defeat runtime level-lowering (#70).
+        return _loggers.GetOrAdd(
+            categoryName,
+            name => new ExtensionLogger(new Logger(SeverityLevel.Trace).WithData(Category, name), GetCurrentConfig, name));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Closes #70. Closes #76.

## What
Two `ExtensionLogger` correctness fixes surfaced (and deferred) during the #57/#59 review loops.

### #70 — runtime level-lowering was double-gated
`ExtensionLoggerProvider.CreateLogger` baked the configured level into the **core `Logger`'s** severity filter at creation time. On a runtime config change (`IOptionsMonitor.OnChange`), `ExtensionLogger.IsEnabled` reflected the new level (it reads the live config), but the cached logger's core `Logger` kept its creation-time filter — so **lowering** a category's level (e.g. `Warning`→`Debug`) left `IsEnabled` returning `true` while the core `Logger` silently dropped the entry.

**Fix:** the provider now constructs the core `Logger` **unfiltered (`Trace`)**, making `ExtensionLogger.IsEnabled` (live config) the single severity gate. Raising levels already worked (IsEnabled short-circuits); lowering now works too.

### #76 — null state key escaped `ArgumentNullException`
`ExtensionLogger.Log` did `props[prop.Key] = …`; a state item with a **null key** threw `ArgumentNullException` from the `Dictionary` indexer, escaping the log call (never-throw violation). Reachable via a `KeyValuePair<string,object>[]` state with a null key (MEL's own state types never admit one).

**Fix:** the state loop now skips items with a null key (or null value).

## Tests
- `TestNullStateKeyIsSkippedWithoutThrowing` — null-keyed item is dropped, sibling still logged, no throw (mutation-verified: reverting the guard fails it).
- `TestRuntimeLevelLoweringEmitsWithUnfilteredCoreLogger` — with a `Trace` core `Logger` (the fixed provider's wiring), a runtime `Warning`→`Debug` lowering emits the newly-enabled entry.
- `TestBakedCoreFilterDropsRuntimeLoweredEntry` — documents the double-gate the fix removes.

> Per #70's own testing note, the fix is verified at the `ExtensionLogger` level with a `MemoryStream`-backed core `Logger` (provider-created loggers write to raw stdout via `Console.OpenStandardOutput()`, which `Console.SetOut` cannot redirect).

## Validation
- `dotnet test`: **185/185** on **net8.0** and **net10.0**; `dotnet build` StyleCop-clean (warnings-as-errors).
