### PR TITLE
Adopt kr/logfmt =/" conformance in the parser and encoder (#75)

### DIFF
--- a/Logfmt.Tests/LogfmtParserTests.cs
+++ b/Logfmt.Tests/LogfmtParserTests.cs
@@ -381,16 +381,19 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
-    /// Tests that a value beginning with a backslash-quote is treated as an unquoted literal.
+    /// Tests that an unquoted value terminates at a double-quote even when preceded by a backslash
+    /// -- escapes are only processed inside quoted values, per the kr/logfmt grammar (#75).
     /// </summary>
     [Fact]
-    public void ParseValueStartingWithEscapedQuoteIsUnquoted()
+    public void ParseUnquotedValueTerminatesAtQuoteAfterBackslash()
     {
       var result = LogfmtParser.Parse("key=\\\"escaped");
 
-      Assert.Single(result);
+      Assert.Equal(2, result.Count);
       Assert.Equal("key", result[0].Key);
-      Assert.Equal("\\\"escaped", result[0].Value);
+      Assert.Equal("\\", result[0].Value);
+      Assert.Equal("escaped", result[1].Key);
+      Assert.Equal(string.Empty, result[1].Value);
     }
 
     /// <summary>
@@ -448,16 +451,31 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
-    /// Tests that an unquoted value may contain multiple equals signs.
+    /// Tests that an unquoted value terminates at '=' per the kr/logfmt grammar, so k=a=b=c parses
+    /// as k=a and b=c (#75).
     /// </summary>
     [Fact]
-    public void ParseUnquotedValueWithMultipleEquals()
+    public void ParseUnquotedValueStopsAtEquals()
     {
       var result = LogfmtParser.Parse("k=a=b=c");
 
-      Assert.Single(result);
+      Assert.Equal(2, result.Count);
       Assert.Equal("k", result[0].Key);
-      Assert.Equal("a=b=c", result[0].Value);
+      Assert.Equal("a", result[0].Value);
+      Assert.Equal("b", result[1].Key);
+      Assert.Equal("c", result[1].Value);
+    }
+
+    /// <summary>
+    /// Tests that an unquoted value terminates at a double-quote per the kr/logfmt grammar (#75).
+    /// </summary>
+    [Fact]
+    public void ParseUnquotedValueStopsAtQuote()
+    {
+      var result = LogfmtParser.Parse("k=a\"b");
+
+      Assert.Equal("k", result[0].Key);
+      Assert.Equal("a", result[0].Value);
     }
 
     /// <summary>

--- a/Logfmt.Tests/LogfmtTests.cs
+++ b/Logfmt.Tests/LogfmtTests.cs
@@ -989,10 +989,10 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
-    /// Tests that values containing equals signs are output correctly.
+    /// Tests that a value containing '=' is quoted so it round-trips under the kr/logfmt grammar (#75).
     /// </summary>
     [Fact]
-    public void ValueContainingEqualsSign()
+    public void ValueContainingEqualsSignIsQuoted()
     {
       var outputStream = new MemoryStream();
       using var logger = new Logger(outputStream);
@@ -1003,7 +1003,17 @@ namespace Logfmt.Tests
       var reader = new StreamReader(outputStream);
       var output = reader.ReadLine();
 
-      Assert.Contains("query=key1=value1", output);
+      // The '=' forces quoting, so a kr/logfmt parser reads the whole value as one field.
+      Assert.Contains("query=\"key1=value1\"", output);
+
+      // Round-trip: the parser recovers the original value.
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      Assert.Equal("key1=value1", fields["query"]);
     }
 
     /// <summary>

--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -263,9 +263,10 @@ namespace Logfmt.Tests
         // Exactly one record: the unicode separator did not start a new line.
         Assert.Null(secondLine);
 
-        // The value (with the separator) is emitted verbatim as a single unquoted token, so a
-        // symmetric wire transform of the separator cannot hide behind the parser round-trip.
-        Assert.Contains("k=" + value, firstLine.Split(' '));
+        // The value contains '=', so under strict kr/logfmt conformance it is emitted as a single
+        // QUOTED token -- the separator (and the '=') stay inside one field and cannot split the
+        // record or forge a key.
+        Assert.Contains("k=\"" + value + "\"", firstLine.Split(' '));
 
         // The separator is not a delimiter: the value stays intact in one field, with no forged key.
         var dict = ParseToDict(firstLine);

--- a/Logfmt/LogfmtParser.cs
+++ b/Logfmt/LogfmtParser.cs
@@ -36,9 +36,9 @@ public static class LogfmtParser
                 break;
             }
 
-            // Parse key (ident bytes are any char (UTF-16 code unit) > ' ', excluding '=')
+            // Parse key (ident bytes are any char (UTF-16 code unit) > ' ', excluding '=' and '"')
             int keyStart = pos;
-            while (pos < len && line[pos] != '=' && line[pos] > ' ')
+            while (pos < len && line[pos] != '=' && line[pos] != '"' && line[pos] > ' ')
             {
                 pos++;
             }
@@ -72,9 +72,10 @@ public static class LogfmtParser
             }
             else
             {
-                // Unquoted value (ident bytes are any char (UTF-16 code unit) > ' ')
+                // Unquoted value: ident bytes are any char (UTF-16 code unit) > ' ', excluding '='
+                // and '"', which terminate the value under the kr/logfmt grammar (#75).
                 int valueStart = pos;
-                while (pos < len && line[pos] > ' ')
+                while (pos < len && line[pos] > ' ' && line[pos] != '=' && line[pos] != '"')
                 {
                     pos++;
                 }

--- a/Logfmt/Logger.cs
+++ b/Logfmt/Logger.cs
@@ -350,8 +350,10 @@ public sealed class Logger : IDisposable
                 needsQuotes = true;
                 hasSpecialChars = true;
             }
-            else if (c <= ' ')
+            else if (c <= ' ' || c == '=')
             {
+                // '=' (like whitespace and '"') terminates an unquoted value under the kr/logfmt
+                // grammar, so a value containing it must be quoted to round-trip (#75).
                 needsQuotes = true;
             }
         }


### PR DESCRIPTION
Closes #75.

## What
Adopts full kr/logfmt `=`/`"` ident-byte conformance in the parser **and** encoder (the option you selected).

Previously the parser cited kr/logfmt but treated `=` and `"` as ordinary characters in unquoted keys/values, so `Parse("k=a=b=c")` returned `[k]=[a=b=c]` where canonical kr/logfmt returns `[k]=[a]`, `[b]=[c]` — and logfmt.net's **own output** containing `=` in a value (`k=a=b`) was **misparsed** by strict logfmt tools.

### Parser
Unquoted key/value scans now terminate at `=` and `"` (the kr/logfmt ident-byte exclusions):
- `Parse("k=a=b=c")` → `[k]=[a]`, `[b]=[c]`
- `Parse("k=a\"b")` → `[k]=[a]`, …

### Encoder
Values containing `=` are now **quoted** (values containing `"` were already quoted), so they round-trip and are interoperable with strict logfmt parsers:
- `Info("query", "key1=value1")` → `query="key1=value1"` (was `query=key1=value1`)
- Round-trip preserved: the parser recovers `key1=value1` exactly.

## ⚠️ Behavior change (minor breaking)
- On-wire output: values containing `=` gain surrounding quotes (values without `=`/`"`/whitespace are unchanged).
- `LogfmtParser` now stops unquoted scans at `=`/`"`, changing results for raw input that embeds them unquoted.

Suggest a minor version bump / release note when you cut the next release.

## Tests
- New: `ParseUnquotedValueStopsAtEquals`, `ParseUnquotedValueStopsAtQuote`.
- Updated to the strict result: `ValueContainingEqualsSignIsQuoted` (+ round-trip), `ParseUnquotedValueTerminatesAtQuoteAfterBackslash`, and the #72 unicode-separator raw-token assertion (the separator value contains `=`, so it is now a quoted token — round-trip and no-forged-field still hold).
- Mutation-verified: reverting the parser `=` stop fails `ParseUnquotedValueStopsAtEquals`; reverting the encoder `=` quoting fails `ValueContainingEqualsSignIsQuoted`.

## Validation
- `dotnet test`: **183/183** on **net8.0** and **net10.0**; `dotnet build` StyleCop-clean (warnings-as-errors).
