### PR TITLE
chore: Add CHANGELOG and bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 1.1.0 / 2026-07-18
+
+- [CHANGE] Encoding: Adopt kr/logfmt `=`/`"` conformance — values containing `=` are now quoted (e.g. `k="a=b"`), and the parser treats unquoted `=` and `"` as delimiters. #65 #82
+- [CHANGE] Extensions.Logging: Category matching is now case-insensitive. #71
+- [BUGFIX] Extensions.Logging: Runtime log-level lowering via `IOptionsMonitor` now takes effect; the core logger no longer double-gates, and `LogLevel.None`/out-of-range levels are never emitted. #80
+- [BUGFIX] Extensions.Logging: `Log` no longer throws on hostile state — null keys, a throwing `ToString()`/formatter/`Exception.Message`, and throwing state enumerators are contained with `[VALUE ERROR]`/`[FORMATTER ERROR]`/`[STATE ERROR]` placeholders. #69 #80
+- [BUGFIX] Logger: Fix a dispose-while-logging race in the core `Logger`. #66
+
+## 1.0.0 / 2026-03-22
+
+- Initial stable release.

--- a/Logfmt/Logfmt.csproj
+++ b/Logfmt/Logfmt.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <AssemblyName>logfmt.net</AssemblyName>
-        <PackageVersion>1.0.0</PackageVersion>
+        <PackageVersion>1.1.0</PackageVersion>
         <Title>logfmt.net</Title>
         <Authors>Ken Haines</Authors>
         <Description>A fast, lightweight structured logging library for .NET using the logfmt format. Includes encoder, parser, Microsoft.Extensions.Logging provider, and OpenTelemetry exporter. ~110ns per log call, zero-alloc when filtered.</Description>


### PR DESCRIPTION
## What

- Add a Prometheus-style `CHANGELOG.md`.
- Bump the package version `1.0.0` → `1.1.0` (`Logfmt/Logfmt.csproj`).

## Why 1.1.0 (minor, not patch)

The work since `v1.0.0` is backward-compatible but includes **observable behavior changes**, not just silent fixes:

- **Wire-format conformance** — the encoder now quotes values containing `=` (e.g. `k="a=b"`) and the parser treats unquoted `=`/`"` as delimiters (kr/logfmt). The emitted bytes change for a common input class.
- **Case-insensitive category matching** — same config, different interpretation.
- Plus genuine bug fixes (runtime level-lowering, never-throw hardening, dispose race).

Per SemVer, a change to already-working observable behavior is more than a patch, so this is a **minor** release. The `CHANGELOG.md` entry doubles as the `1.1.0` release notes.

## Notes

- Follows the Prometheus CHANGELOG format: reverse-chronological `## X.Y.Z / YYYY-MM-DD` sections, one bullet per change tagged `[CHANGE]`/`[BUGFIX]` (ordered by importance), user-facing changes only (test-only, CI, docs, and Dependabot commits omitted).
- Adjust the `1.1.0` date at tag time if the release lands on a different day.
- Docs/version chore — no code logic changed; build is clean (0 warnings, both TFMs).
