### PR TITLE
Harden never-throw parity and tighten test rigor (audit follow-up)

### DIFF
--- a/Logfmt.Tests/ExtensionLoggingTests.cs
+++ b/Logfmt.Tests/ExtensionLoggingTests.cs
@@ -148,8 +148,13 @@ namespace Logfmt.Tests
       ILogger logger = new ExtensionLogger(new Logger(outputStream), this.GetConfiguration, "test");
 
       using var scope = logger.BeginScope("test scope");
+      using var scope2 = logger.BeginScope("another scope");
 
       Assert.NotNull(scope);
+
+      // BeginScope is a no-op that always returns the same shared singleton; asserting reference
+      // equality across two calls kills a mutation that returns a fresh disposable per call.
+      Assert.Same(scope, scope2);
     }
 
     /// <summary>
@@ -1028,8 +1033,16 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var content = new StreamReader(outputStream).ReadToEnd();
 
+      // Structural assertion: parse the single emitted record and assert msg is exactly "after"
+      // (kills a payload mutation that an over-broad substring check would miss); "before" was filtered.
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(content.Trim()))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      Assert.Equal("after", fields["msg"]);
       Assert.DoesNotContain("before", content);
-      Assert.Contains("after", content);
     }
 
     /// <summary>
@@ -1155,6 +1168,31 @@ namespace Logfmt.Tests
       Assert.Equal("value", fields["good"]);
       Assert.Contains("STATE ERROR", fields["state_error"]);
       Assert.Equal("survived", fields[Logger.MessageKey]);
+    }
+
+    /// <summary>
+    /// Tests that provider Dispose clears the per-category logger cache (so a later CreateLogger yields
+    /// a fresh instance) and is idempotent. The cached loggers wrap stdout and are intentionally not
+    /// disposed (documented on the provider).
+    /// </summary>
+    [Fact]
+    public void TestProviderDisposeClearsCacheAndIsIdempotent()
+    {
+      var config = new ExtensionLoggerConfiguration();
+      config.LogLevel["Default"] = LogLevel.Information;
+      var provider = new ExtensionLoggerProvider(new TestOptionsMonitor(config));
+
+      var logger1 = provider.CreateLogger("cat");
+      Assert.Same(logger1, provider.CreateLogger("cat"));
+
+      provider.Dispose();
+
+      // The cache was cleared, so a post-dispose CreateLogger builds a fresh instance.
+      var logger2 = provider.CreateLogger("cat");
+      Assert.NotSame(logger1, logger2);
+
+      // Dispose is idempotent.
+      Assert.Null(Record.Exception(() => provider.Dispose()));
     }
 
     private ExtensionLoggerConfiguration GetConfiguration()

--- a/Logfmt.Tests/LogfmtParserTests.cs
+++ b/Logfmt.Tests/LogfmtParserTests.cs
@@ -536,5 +536,21 @@ namespace Logfmt.Tests
       Assert.Equal("b", result[1].Key);
       Assert.Equal("2", result[1].Value);
     }
+
+    /// <summary>
+    /// Tests that a quoted value ending in a lone backslash at end-of-input parses without reading
+    /// past the buffer, keeping the trailing backslash as a literal.
+    /// </summary>
+    [Fact]
+    public void ParseQuotedValueEndingInBackslashAtEofDoesNotThrow()
+    {
+      // A quoted value whose final character is a lone backslash at end-of-input must not read past
+      // the buffer; the trailing backslash is kept as a literal.
+      var result = LogfmtParser.Parse("k=\"val\\");
+
+      Assert.Single(result);
+      Assert.Equal("k", result[0].Key);
+      Assert.Equal("val\\", result[0].Value);
+    }
   }
 }

--- a/Logfmt.Tests/LogfmtTests.cs
+++ b/Logfmt.Tests/LogfmtTests.cs
@@ -1196,6 +1196,36 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
+    /// Tests the documented reserved-field behavior: a user key colliding with a reserved field (msg)
+    /// produces a duplicate field. logfmt permits duplicate keys and typical consumers take the last.
+    /// </summary>
+    [Fact]
+    public void UserKeyCollidingWithReservedFieldProducesDuplicate()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      logger.Log(SeverityLevel.Info, "primary", "msg", "shadow");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      var msgCount = 0;
+      foreach (var field in output.Split(' '))
+      {
+        if (field.StartsWith("msg=", StringComparison.Ordinal))
+        {
+          msgCount++;
+        }
+      }
+
+      // Two msg fields: the reserved one from the message parameter, then the colliding user pair.
+      Assert.Equal(2, msgCount);
+      Assert.Contains("msg=\"primary\"", output);
+      Assert.Contains("msg=\"shadow\"", output);
+    }
+
+    /// <summary>
     /// Tests that typed values are filtered with zero cost when level is disabled.
     /// </summary>
     [Fact]

--- a/Logfmt.Tests/LogfmtTests.cs
+++ b/Logfmt.Tests/LogfmtTests.cs
@@ -1177,6 +1177,25 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
+    /// Tests that a typed value whose ToString() throws does not escape Log (never-throw contract)
+    /// and is rendered as a [VALUE ERROR] placeholder.
+    /// </summary>
+    [Fact]
+    public void LogWithThrowingTypedValueDoesNotThrow()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      var ex = Record.Exception(() => logger.Log(SeverityLevel.Info, "test", "key", new ThrowingToString()));
+
+      Assert.Null(ex);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var thrownOutput = new StreamReader(outputStream).ReadLine();
+      Assert.Contains("[VALUE ERROR:", thrownOutput);
+    }
+
+    /// <summary>
     /// Tests that typed values are filtered with zero cost when level is disabled.
     /// </summary>
     [Fact]
@@ -1614,6 +1633,11 @@ namespace Logfmt.Tests
     /// <summary>
     /// A <see cref="MemoryStream"/> whose writability can be toggled at runtime for testing.
     /// </summary>
+    private sealed class ThrowingToString
+    {
+      public override string ToString() => throw new InvalidOperationException("boom-tostring");
+    }
+
     private sealed class ToggleWritableStream : MemoryStream
     {
       /// <summary>

--- a/Logfmt.Tests/OpenTelemetryLoggingTests.cs
+++ b/Logfmt.Tests/OpenTelemetryLoggingTests.cs
@@ -40,10 +40,12 @@ namespace Logfmt.Tests
     {
       var exporter = new ConsoleLogExporter();
 
-      Assert.NotNull(exporter);
+      // An active exporter reports Success; a disposed one reports Failure without throwing.
+      Assert.Equal(ExportResult.Success, exporter.Export(default));
 
-      // Should not throw when disposing
       exporter.Dispose();
+
+      Assert.Equal(ExportResult.Failure, exporter.Export(default));
     }
 
     /// <summary>
@@ -56,7 +58,8 @@ namespace Logfmt.Tests
       var logger = new Logger(outputStream);
       var exporter = new ConsoleLogExporter(logger);
 
-      Assert.NotNull(exporter);
+      // The custom-logger exporter is functional: Export returns Success on an empty batch.
+      Assert.Equal(ExportResult.Success, exporter.Export(default));
 
       exporter.Dispose();
     }
@@ -109,10 +112,11 @@ namespace Logfmt.Tests
       var reader = new StreamReader(outputStream);
       var output = reader.ReadLine();
 
-      // Should contain basic log structure with timestamp
-      Assert.Contains("level=info", output, StringComparison.InvariantCultureIgnoreCase);
-      Assert.Contains("msg=\"Test message from OpenTelemetry\"", output, StringComparison.InvariantCultureIgnoreCase);
-      Assert.Contains("ts=", output, StringComparison.InvariantCultureIgnoreCase);
+      // Structural: parse the record and assert exact field values.
+      var fields = ParseFields(output);
+      Assert.Equal("info", fields["level"]);
+      Assert.Equal("Test message from OpenTelemetry", fields["msg"]);
+      Assert.True(fields.ContainsKey("ts"));
     }
 
     /// <summary>
@@ -150,10 +154,12 @@ namespace Logfmt.Tests
       var warningLine = reader.ReadLine();
       var errorLine = reader.ReadLine();
 
-      Assert.Contains("level=debug", debugLine, StringComparison.InvariantCultureIgnoreCase);
-      Assert.Contains("level=info", infoLine, StringComparison.InvariantCultureIgnoreCase);
-      Assert.Contains("level=warn", warningLine, StringComparison.InvariantCultureIgnoreCase);
-      Assert.Contains("level=error", errorLine, StringComparison.InvariantCultureIgnoreCase);
+      Assert.Equal("debug", ParseFields(debugLine)["level"]);
+      Assert.Equal("info", ParseFields(infoLine)["level"]);
+      Assert.Equal("warn", ParseFields(warningLine)["level"]);
+      Assert.Equal("error", ParseFields(errorLine)["level"]);
+      Assert.Equal("Debug message", ParseFields(debugLine)["msg"]);
+      Assert.Equal("Error message", ParseFields(errorLine)["msg"]);
     }
 
     /// <summary>
@@ -336,6 +342,55 @@ namespace Logfmt.Tests
       outputStream.Seek(0, SeekOrigin.Begin);
       var output = new StreamReader(outputStream).ReadLine();
       Assert.Contains("exception_msg=ThrowingMessageException", output);
+    }
+
+    /// <summary>
+    /// Tests that a hostile record (whose exception StackTrace getter throws inside ExtractAttributes)
+    /// is contained per-record with an [EXPORT ERROR] marker and does not abort export of the other
+    /// records in the same run.
+    /// </summary>
+    [Fact]
+    public void TestOpenTelemetryHostileRecordDoesNotAbortBatch()
+    {
+      var outputStream = new MemoryStream();
+      var customLogger = new Logger(outputStream);
+
+      using var loggerFactory = LoggerFactory.Create(builder =>
+      {
+        builder.AddOpenTelemetry(options =>
+        {
+          options.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogExporter(customLogger)));
+        });
+      });
+
+      var logger = loggerFactory.CreateLogger("cat");
+      logger.LogInformation("first");
+      logger.LogError(new ThrowingStackTraceException(), "hostile");
+      logger.LogInformation("third");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var lines = new StreamReader(outputStream).ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+      Assert.Equal(3, lines.Length);
+      Assert.Equal("first", ParseFields(lines[0])["msg"]);
+      Assert.Contains("[EXPORT ERROR:", ParseFields(lines[1])["msg"]);
+      Assert.Equal("third", ParseFields(lines[2])["msg"]);
+    }
+
+    private static Dictionary<string, string> ParseFields(string line)
+    {
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(line))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      return fields;
+    }
+
+    private sealed class ThrowingStackTraceException : Exception
+    {
+      public override string StackTrace => throw new InvalidOperationException("stack getter threw");
     }
 
     private sealed class ThrowingMessageException : Exception

--- a/Logfmt.Tests/OpenTelemetryLoggingTests.cs
+++ b/Logfmt.Tests/OpenTelemetryLoggingTests.cs
@@ -71,11 +71,15 @@ namespace Logfmt.Tests
       var logger = new Logger(outputStream);
       var exporter = new ConsoleLogExporter(logger);
 
-      // Should not throw
+      Assert.True(outputStream.CanWrite);
+
       exporter.Dispose();
 
-      // Double dispose should not throw
-      exporter.Dispose();
+      // Dispose trickles down to the inner Logger, which disposes the underlying stream.
+      Assert.False(outputStream.CanWrite);
+
+      // Double dispose is idempotent and does not throw.
+      Assert.Null(Record.Exception(() => exporter.Dispose()));
     }
 
     /// <summary>
@@ -271,6 +275,72 @@ namespace Logfmt.Tests
 
       Assert.Contains("event_id=42", output);
       Assert.Contains("event_name=MyEvent", output);
+    }
+
+    /// <summary>
+    /// Tests that an exception with a null StackTrace (a never-thrown exception) is exported with an
+    /// empty exception_stack rather than crashing.
+    /// </summary>
+    [Fact]
+    public void TestOpenTelemetryExceptionWithNullStackTraceEmitsEmptyStack()
+    {
+      var outputStream = new MemoryStream();
+      var customLogger = new Logger(outputStream);
+
+      using var loggerFactory = LoggerFactory.Create(builder =>
+      {
+        builder.AddOpenTelemetry(options =>
+        {
+          options.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogExporter(customLogger)));
+        });
+      });
+
+      var logger = loggerFactory.CreateLogger("cat");
+      logger.LogError(new InvalidOperationException("boom"), "err");
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(output))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      Assert.Equal("boom", fields["exception_msg"]);
+      Assert.Equal(string.Empty, fields["exception_stack"]);
+    }
+
+    /// <summary>
+    /// Tests that an exception whose Message getter throws does not escape export (never-throw); the
+    /// exporter falls back to the exception type name.
+    /// </summary>
+    [Fact]
+    public void TestOpenTelemetryExceptionWithThrowingMessageIsContained()
+    {
+      var outputStream = new MemoryStream();
+      var customLogger = new Logger(outputStream);
+
+      using var loggerFactory = LoggerFactory.Create(builder =>
+      {
+        builder.AddOpenTelemetry(options =>
+        {
+          options.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogExporter(customLogger)));
+        });
+      });
+
+      var logger = loggerFactory.CreateLogger("cat");
+
+      var ex = Record.Exception(() => logger.LogError(new ThrowingMessageException(), "err"));
+      Assert.Null(ex);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+      Assert.Contains("exception_msg=ThrowingMessageException", output);
+    }
+
+    private sealed class ThrowingMessageException : Exception
+    {
+      public override string Message => throw new InvalidOperationException("message getter threw");
     }
   }
 }

--- a/Logfmt.Tests/OpenTelemetryLoggingTests.cs
+++ b/Logfmt.Tests/OpenTelemetryLoggingTests.cs
@@ -347,7 +347,7 @@ namespace Logfmt.Tests
     /// <summary>
     /// Tests that a hostile record (whose exception StackTrace getter throws inside ExtractAttributes)
     /// is contained per-record with an [EXPORT ERROR] marker and does not abort export of the other
-    /// records in the same run.
+    /// records in the SAME batch (a batching processor delivers all three to one Export call).
     /// </summary>
     [Fact]
     public void TestOpenTelemetryHostileRecordDoesNotAbortBatch()
@@ -355,11 +355,13 @@ namespace Logfmt.Tests
       var outputStream = new MemoryStream();
       var customLogger = new Logger(outputStream);
 
-      using var loggerFactory = LoggerFactory.Create(builder =>
+      // A batching processor so all three records reach the exporter in a SINGLE Export call; this
+      // proves the per-record try/catch lets the loop CONTINUE past the hostile middle record.
+      var loggerFactory = LoggerFactory.Create(builder =>
       {
         builder.AddOpenTelemetry(options =>
         {
-          options.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogExporter(customLogger)));
+          options.AddProcessor(new BatchLogRecordExportProcessor(new ConsoleLogExporter(customLogger)));
         });
       });
 
@@ -368,8 +370,12 @@ namespace Logfmt.Tests
       logger.LogError(new ThrowingStackTraceException(), "hostile");
       logger.LogInformation("third");
 
-      outputStream.Seek(0, SeekOrigin.Begin);
-      var lines = new StreamReader(outputStream).ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+      // Dispose flushes the queued batch through one Export call before we read. It also disposes the
+      // underlying stream, so read the captured bytes via ToArray() (valid after a MemoryStream close).
+      loggerFactory.Dispose();
+
+      var text = System.Text.Encoding.UTF8.GetString(outputStream.ToArray());
+      var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
       Assert.Equal(3, lines.Length);
       Assert.Equal("first", ParseFields(lines[0])["msg"]);

--- a/Logfmt/ExtensionLogging/ExtensionLogger.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLogger.cs
@@ -104,13 +104,13 @@ public class ExtensionLogger : ILogger
                     }
                     catch (Exception ex)
                     {
-                        props[prop.Key] = $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
+                        props[prop.Key] = $"[VALUE ERROR: {Logger.SafeExceptionMessage(ex)}]";
                     }
                 }
             }
             catch (Exception ex)
             {
-                props["state_error"] = $"[STATE ERROR: {SafeExceptionMessage(ex)}]";
+                props["state_error"] = $"[STATE ERROR: {Logger.SafeExceptionMessage(ex)}]";
             }
         }
 
@@ -123,7 +123,7 @@ public class ExtensionLogger : ILogger
             }
             catch (Exception ex)
             {
-                props[Logger.MessageKey] = $"[FORMATTER ERROR: {SafeExceptionMessage(ex)}]";
+                props[Logger.MessageKey] = $"[FORMATTER ERROR: {Logger.SafeExceptionMessage(ex)}]";
             }
         }
 
@@ -138,19 +138,5 @@ public class ExtensionLogger : ILogger
         }
 
         logger.Log(sevLevel, props.ToArray());
-    }
-
-    private static string SafeExceptionMessage(Exception ex)
-    {
-        try
-        {
-            return ex.Message;
-        }
-        catch (Exception)
-        {
-            // Exception.Message is overridable and can itself throw; fall back to the (non-virtual,
-            // safe) type name so the recovery path upholds the never-throw contract.
-            return ex.GetType().Name;
-        }
     }
 }

--- a/Logfmt/ExtensionLogging/ExtensionLoggerProvider.cs
+++ b/Logfmt/ExtensionLogging/ExtensionLoggerProvider.cs
@@ -52,7 +52,10 @@ public sealed class ExtensionLoggerProvider : ILoggerProvider
     /// <inheritdoc/>
     public void Dispose()
     {
-        // noop
+        // The cached ExtensionLoggers wrap core Loggers that write to Console.OpenStandardOutput().
+        // They are intentionally NOT disposed here: each Log() flushes immediately (so no buffered
+        // data is lost) and disposing would close the shared stdout handle. We only drop the cache
+        // and unsubscribe the options-change token.
         _loggers.Clear();
         _onChangeToken?.Dispose();
     }

--- a/Logfmt/Logger.cs
+++ b/Logfmt/Logger.cs
@@ -131,6 +131,13 @@ public sealed class Logger : IDisposable
     /// </summary>
     /// <param name="severity">The severity of the log entry.</param>
     /// <param name="kvpairs">labels and values to include with the entry.</param>
+    /// <remarks>
+    /// The logger always emits the reserved fields <c>ts</c> (timestamp) and <c>level</c> first, and
+    /// the <c>msg</c> field is emitted by the message-based overloads. A caller-supplied key that
+    /// sanitizes to <c>ts</c>, <c>level</c>, or <c>msg</c> is still written, producing a duplicate
+    /// field; the logfmt format permits duplicate keys and typical consumers take the last value.
+    /// Avoid reusing these reserved keys to keep output unambiguous.
+    /// </remarks>
     public void Log(SeverityLevel severity, params KeyValuePair<string, string>[] kvpairs)
     {
         if (!IsEnabled(severity))
@@ -263,8 +270,20 @@ public sealed class Logger : IDisposable
         pairs[0] = new KeyValuePair<string, string>(MessageKey, msg);
         for (var i = 0; i < kvpairs.Length; i += 2)
         {
-            var key = kvpairs[i]?.ToString() ?? string.Empty;
-            var value = kvpairs[i + 1]?.ToString();
+            var key = SafeToString(kvpairs[i]);
+
+            // Preserve the existing null-value contract (a null renders as "null" in AppendValueField);
+            // only a THROWING ToString is contained, upholding the never-throw contract.
+            string? value;
+            try
+            {
+                value = kvpairs[i + 1]?.ToString();
+            }
+            catch (Exception ex)
+            {
+                value = $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
+            }
+
             pairs[1 + (i / 2)] = new KeyValuePair<string, string>(key, value!);
         }
 
@@ -291,6 +310,48 @@ public sealed class Logger : IDisposable
     public void SetSeverityFilter(SeverityLevel level)
     {
         levelFilter = level;
+    }
+
+    /// <summary>
+    /// Converts a value to its string representation without ever throwing. A value whose
+    /// <see cref="object.ToString"/> override throws yields a <c>[VALUE ERROR: ...]</c> placeholder so
+    /// the logging call upholds the never-throw contract.
+    /// </summary>
+    /// <param name="value">The value to stringify.</param>
+    /// <returns>The string representation, an empty string for null, or a placeholder on failure.</returns>
+    internal static string SafeToString(object? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            return value.ToString() ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            return $"[VALUE ERROR: {SafeExceptionMessage(ex)}]";
+        }
+    }
+
+    /// <summary>
+    /// Returns an exception's message without ever throwing; a custom <see cref="Exception.Message"/>
+    /// override can itself throw, in which case the exception type name is returned instead.
+    /// </summary>
+    /// <param name="ex">The exception whose message is required.</param>
+    /// <returns>The message, or the exception type name if the getter throws.</returns>
+    internal static string SafeExceptionMessage(Exception ex)
+    {
+        try
+        {
+            return ex.Message;
+        }
+        catch (Exception)
+        {
+            return ex.GetType().Name;
+        }
     }
 
     private static void CheckParamArrayLength<T>(T[] kvpairs)

--- a/Logfmt/OpenTelemetryLogging/ConsoleLogExporter.cs
+++ b/Logfmt/OpenTelemetryLogging/ConsoleLogExporter.cs
@@ -52,9 +52,9 @@ public class ConsoleLogExporter : BaseExporter<LogRecord>
             }
             catch (Exception ex)
             {
-                // Defense in depth: ExtractAttributes is already throw-safe, but never let a single
-                // malformed record fail the whole batch export. Emit a best-effort diagnostic and
-                // continue so the remaining records are still exported.
+                // Never let a single malformed record fail the whole batch export: a member the
+                // extraction reads (e.g. a hostile Exception.StackTrace) can still throw, so contain it
+                // here, emit a best-effort diagnostic, and continue so the remaining records export.
                 try
                 {
                     _logger.Log(SeverityLevel.Error, new KeyValuePair<string, string>(Logger.MessageKey, $"[EXPORT ERROR: {Logger.SafeExceptionMessage(ex)}]"));

--- a/Logfmt/OpenTelemetryLogging/ConsoleLogExporter.cs
+++ b/Logfmt/OpenTelemetryLogging/ConsoleLogExporter.cs
@@ -45,7 +45,24 @@ public class ConsoleLogExporter : BaseExporter<LogRecord>
 
         foreach (var record in batch)
         {
-            _logger.Log(record.LogLevel.ToSeverityLevel(), ExtractAttributes(record));
+            try
+            {
+                _logger.Log(record.LogLevel.ToSeverityLevel(), ExtractAttributes(record));
+            }
+            catch (Exception ex)
+            {
+                // Defense in depth: ExtractAttributes is already throw-safe, but never let a single
+                // malformed record fail the whole batch export. Emit a best-effort diagnostic and
+                // continue so the remaining records are still exported.
+                try
+                {
+                    _logger.Log(SeverityLevel.Error, new KeyValuePair<string, string>(Logger.MessageKey, $"[EXPORT ERROR: {Logger.SafeExceptionMessage(ex)}]"));
+                }
+                catch (Exception)
+                {
+                    // Swallow -- upholding the never-throw contract even if the diagnostic write fails.
+                }
+            }
         }
 
         return ExportResult.Success;
@@ -70,7 +87,7 @@ public class ConsoleLogExporter : BaseExporter<LogRecord>
         attributes.Add(new KeyValuePair<string, string>(Logger.MessageKey, record.FormattedMessage ?? record.Body ?? string.Empty));
         if (record.Exception is not null)
         {
-            attributes.Add(new KeyValuePair<string, string>("exception_msg", record.Exception.Message));
+            attributes.Add(new KeyValuePair<string, string>("exception_msg", Logger.SafeExceptionMessage(record.Exception)));
             attributes.Add(new KeyValuePair<string, string>("exception_stack", record.Exception.StackTrace ?? string.Empty));
         }
 
@@ -99,7 +116,7 @@ public class ConsoleLogExporter : BaseExporter<LogRecord>
         {
             foreach (var a in record.Attributes)
             {
-                attributes.Add(new KeyValuePair<string, string>(a.Key, a.Value?.ToString() ?? "null"));
+                attributes.Add(new KeyValuePair<string, string>(a.Key, a.Value is null ? "null" : Logger.SafeToString(a.Value)));
             }
         }
 

--- a/Logfmt/OpenTelemetryLogging/ConsoleLogExporter.cs
+++ b/Logfmt/OpenTelemetryLogging/ConsoleLogExporter.cs
@@ -39,7 +39,8 @@ public class ConsoleLogExporter : BaseExporter<LogRecord>
     {
         if (_isDisposed)
         {
-            Console.Error.WriteLine("Warning: Attempted to export logs using a disposed ConsoleLogExporter.");
+            // A disposed exporter reports Failure rather than writing a diagnostic to a possibly
+            // hostile or redirected stderr (which could throw and break the never-throw contract).
             return ExportResult.Failure;
         }
 


### PR DESCRIPTION
## What & why

Follow-up to the red-team / security / quality audit of the codebase. Addresses the actionable findings that **don't** change the wire format (control-char escaping is a separate PR). No behavior change except never-throw hardening.

### Never-throw completeness (S3)
- `Logger.Log(severity, msg, object[])` now contains a throwing value `ToString()` as a `[VALUE ERROR: …]` placeholder — parity with the MEL adapter. Null values still render as `null`.
- `ConsoleLogExporter` reads exception messages via a throw-safe helper and wraps per-record export so one malformed record can't fail the whole batch.

### Docs (S2, G2)
- Document `ts`/`level`/`msg` as reserved fields (a colliding user key produces a duplicate; logfmt permits duplicate keys and typical consumers take the last value).
- Explain why the provider intentionally doesn't dispose its stdout-backed inner loggers (immediate flush → no data loss; closing stdout is undesirable).

### Test gaps (G1, G3)
- Quoted value ending in a lone backslash at EOF (parser must not read past the buffer).
- Exporter throwing-`Message` and null-`StackTrace` paths.

### Vacuous / weak tests fixed (V1, V2, V3)
- `TestConsoleLogExporterDispose` now asserts the inner stream is closed (was zero assertions).
- Runtime level-lowering test parses the exact `msg` (was an over-broad `Contains("after")` that a payload mutation survived).
- `TestBeginScopeReturnsDisposable` asserts the shared singleton (was `NotNull` on a never-null value).

## Validation
- **195/195** tests on **net8.0** and **net10.0**; `dotnet build -c Release` → **0 warnings**.
- Every new/tightened test is **mutation-verified**: reverting each production hunk (value try/catch, exporter `SafeExceptionMessage`, `?? string.Empty` stack fallback, parser `pos+1<len` bound, `_loggers.Clear()`, exporter `_logger.Dispose()`) turns its test **RED**.

_Self-authored → informational review; AI does not merge._
