### PR TITLE
Escape control characters and Unicode line separators (audit S1)

### DIFF
--- a/Logfmt.Tests/LogfmtParserTests.cs
+++ b/Logfmt.Tests/LogfmtParserTests.cs
@@ -552,5 +552,33 @@ namespace Logfmt.Tests
       Assert.Equal("k", result[0].Key);
       Assert.Equal("val\\", result[0].Value);
     }
+
+    /// <summary>
+    /// Tests that a \uXXXX escape in a quoted value is decoded to the corresponding character.
+    /// </summary>
+    [Fact]
+    public void ParseDecodesUnicodeEscape()
+    {
+      var result = LogfmtParser.Parse("k=\"a\\u2028b\\u001bc\"");
+
+      Assert.Single(result);
+      Assert.Equal("a\u2028b\u001bc", result[0].Value);
+    }
+
+    /// <summary>
+    /// Tests that a malformed \u escape (invalid hex, or truncated at end-of-input) does not throw and
+    /// keeps the backslash literally.
+    /// </summary>
+    [Fact]
+    public void ParseMalformedUnicodeEscapeIsHandledGracefully()
+    {
+      var badHex = LogfmtParser.Parse("k=\"a\\uZZZZb\"");
+      Assert.Single(badHex);
+      Assert.Equal("a\\uZZZZb", badHex[0].Value);
+
+      var truncated = LogfmtParser.Parse("k=\"a\\u12");
+      Assert.Single(truncated);
+      Assert.Equal("a\\u12", truncated[0].Value);
+    }
   }
 }

--- a/Logfmt.Tests/LogfmtTests.cs
+++ b/Logfmt.Tests/LogfmtTests.cs
@@ -431,6 +431,28 @@ namespace Logfmt.Tests
     }
 
     /// <summary>
+    /// Tests that a literal backslash-u sequence in user text (e.g. \u0041) round-trips as literal text
+    /// and is NOT decoded to a character -- the encoder doubles the backslash, so the parser's \uXXXX
+    /// decode never fires on it.
+    /// </summary>
+    [Fact]
+    public void LiteralBackslashUTextRoundTripsWithoutDecoding()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      var value = @"\u0041 and \uZZZZ"; // literal backslash-u sequences, not real escapes
+      logger.Info("m", "k", value);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      // The encoder doubles the backslash, so the parser restores the literal text (no decode to 'A').
+      Assert.Contains(@"k=""\\u0041 and \\uZZZZ""", output);
+      Assert.Equal(value, ParseSingle(output)["k"]);
+    }
+
+    /// <summary>
     /// Tests that double quotes in values are escaped.
     /// </summary>
     [Fact]

--- a/Logfmt.Tests/LogfmtTests.cs
+++ b/Logfmt.Tests/LogfmtTests.cs
@@ -378,7 +378,56 @@ namespace Logfmt.Tests
       var reader = new StreamReader(outputStream);
       var output = reader.ReadLine();
 
-      Assert.Contains("data=\"hello\tworld\"", output);
+      // Tab is escaped as \t (previously emitted raw); the value round-trips through the parser.
+      Assert.Contains("data=\"hello\\tworld\"", output);
+      Assert.Equal("hello\tworld", ParseSingle(output)["data"]);
+    }
+
+    /// <summary>
+    /// Tests that C0/C1 control characters are escaped as \uXXXX (never emitted raw, closing the
+    /// terminal-escape-injection vector) and round-trip through the parser.
+    /// </summary>
+    [Fact]
+    public void ControlCharactersAreEscapedAsUnicodeAndRoundTrip()
+    {
+      var outputStream = new MemoryStream();
+      using var logger = new Logger(outputStream);
+
+      var value = "a\u0000b\u001bc\u0007d"; // NUL, ESC (terminal-escape vector), BEL
+      logger.Info("m", "k", value);
+
+      outputStream.Seek(0, SeekOrigin.Begin);
+      var output = new StreamReader(outputStream).ReadLine();
+
+      Assert.Contains("k=\"a\\u0000b\\u001bc\\u0007d\"", output);
+      Assert.DoesNotContain('\u001b', output); // no raw ESC survives (ordinal char check)
+      Assert.Equal(value, ParseSingle(output)["k"]);
+    }
+
+    /// <summary>
+    /// Tests that Unicode line separators (LS/PS/NEL) are escaped and never emitted raw, so a value
+    /// cannot forge a second record in consumers that treat them as line terminators. Round-trips.
+    /// </summary>
+    [Fact]
+    public void UnicodeLineSeparatorsAreEscapedAndNeverRaw()
+    {
+      foreach (var (sep, esc) in new[] { ("\u2028", "\\u2028"), ("\u2029", "\\u2029"), ("\u0085", "\\u0085") })
+      {
+        var outputStream = new MemoryStream();
+        using var logger = new Logger(outputStream);
+
+        var value = "x" + sep + "y";
+        logger.Info("m", "k", value);
+
+        outputStream.Seek(0, SeekOrigin.Begin);
+        var reader = new StreamReader(outputStream);
+        var output = reader.ReadLine();
+
+        Assert.Null(reader.ReadLine()); // exactly one physical record -- no forged second line
+        Assert.DoesNotContain(sep, output, StringComparison.Ordinal);
+        Assert.Contains("k=\"x" + esc + "y\"", output);
+        Assert.Equal(value, ParseSingle(output)["k"]);
+      }
     }
 
     /// <summary>
@@ -1049,7 +1098,9 @@ namespace Logfmt.Tests
       var reader = new StreamReader(outputStream);
       var output = reader.ReadLine();
 
-      Assert.Contains("data=\"line1\\r\\nline2\t\\\"quoted\\\"\\\\path\"", output);
+      // CR/LF/TAB are escaped (\r \n \t), quotes and backslash escaped; the value round-trips.
+      Assert.Contains("data=\"line1\\r\\nline2\\t\\\"quoted\\\"\\\\path\"", output);
+      Assert.Equal("line1\r\nline2\t\"quoted\"\\path", ParseSingle(output)["data"]);
     }
 
     /// <summary>
@@ -1663,6 +1714,17 @@ namespace Logfmt.Tests
     /// <summary>
     /// A <see cref="MemoryStream"/> whose writability can be toggled at runtime for testing.
     /// </summary>
+    private static Dictionary<string, string> ParseSingle(string line)
+    {
+      var fields = new Dictionary<string, string>();
+      foreach (var kvp in LogfmtParser.Parse(line))
+      {
+        fields[kvp.Key] = kvp.Value;
+      }
+
+      return fields;
+    }
+
     private sealed class ThrowingToString
     {
       public override string ToString() => throw new InvalidOperationException("boom-tostring");

--- a/Logfmt.Tests/UnicodeHandlingTests.cs
+++ b/Logfmt.Tests/UnicodeHandlingTests.cs
@@ -263,12 +263,8 @@ namespace Logfmt.Tests
         // Exactly one record: the unicode separator did not start a new line.
         Assert.Null(secondLine);
 
-        // The value contains '=', so under strict kr/logfmt conformance it is emitted as a single
-        // QUOTED token -- the separator (and the '=') stay inside one field and cannot split the
-        // record or forge a key.
-        Assert.Contains("k=\"" + value + "\"", firstLine.Split(' '));
-
-        // The separator is not a delimiter: the value stays intact in one field, with no forged key.
+        // The separator is not a logfmt delimiter and (for line separators) is escaped, so the value
+        // stays intact in one field and round-trips exactly, with no forged key.
         var dict = ParseToDict(firstLine);
         Assert.Equal(value, dict["k"]);
         Assert.False(dict.ContainsKey("injected"));

--- a/Logfmt/LogfmtParser.cs
+++ b/Logfmt/LogfmtParser.cs
@@ -124,6 +124,20 @@ public static class LogfmtParser
                         buffer.Append('\t');
                         pos += 2;
                         break;
+                    case 'u':
+                        if (pos + 6 <= len &&
+                            int.TryParse(line.AsSpan(pos + 2, 4), System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out int codePoint))
+                        {
+                            buffer.Append((char)codePoint);
+                            pos += 6;
+                        }
+                        else
+                        {
+                            buffer.Append(line[pos]);
+                            pos++;
+                        }
+
+                        break;
                     default:
                         buffer.Append(line[pos]);
                         pos++;

--- a/Logfmt/Logger.cs
+++ b/Logfmt/Logger.cs
@@ -391,6 +391,8 @@ public sealed class Logger : IDisposable
                c == '_';
     }
 
+    private static bool IsEscapable(char c) => char.IsControl(c) || c == '\u2028' || c == '\u2029';
+
     private static void AppendValueField(StringBuilder buffer, string key, string value)
     {
         // Handle null values
@@ -406,8 +408,11 @@ public sealed class Logger : IDisposable
         for (int i = 0; i < value.Length; i++)
         {
             char c = value[i];
-            if (c == '"' || c == '\\' || c == '\r' || c == '\n')
+            if (c == '"' || c == '\\' || IsEscapable(c))
             {
+                // Quote and escape the delimiters plus any control character or Unicode line
+                // separator, so a value cannot forge extra records or inject terminal escape sequences
+                // into downstream consumers (char.IsControl covers CR/LF/TAB and the C0/C1 controls).
                 needsQuotes = true;
                 hasSpecialChars = true;
             }
@@ -443,8 +448,20 @@ public sealed class Logger : IDisposable
                     case '\n':
                         buffer.Append("\\n");
                         break;
+                    case '\t':
+                        buffer.Append("\\t");
+                        break;
                     default:
-                        buffer.Append(c);
+                        if (IsEscapable(c))
+                        {
+                            buffer.Append("\\u");
+                            buffer.Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            buffer.Append(c);
+                        }
+
                         break;
                 }
             }


### PR DESCRIPTION
## What & why

Implements the audit's **S1** finding — the one wire-format change, deliberately separated from PR #89. Closes a **log-forgery + terminal-escape-injection** vector: the value encoder previously emitted control characters (incl. `ESC`) and the Unicode line separators `U+2028`/`U+2029`/`U+0085` (NEL) **raw**.

### Encoder (`Logger.AppendValueField`)
- Any `char.IsControl` character (C0/C1, including `TAB` and NEL `U+0085`) and `U+2028`/`U+2029` are now **quoted and escaped** — `TAB` as `\t`, the rest as `\uXXXX` — instead of raw.
- Closes the forgery vector: a value with `U+2028`/`U+2029`/NEL could forge a second record in consumers that treat them as line terminators (e.g. .NET `ReadOnlySpan.EnumerateLines()` / `ReplaceLineEndings()`); and the terminal-escape vector (raw `ESC` and other C0 controls reaching a terminal log viewer).

### Parser (`LogfmtParser.ParseQuotedValue`)
- Decodes `\uXXXX` (4 hex digits, case-insensitive) back to the character, with graceful handling of malformed/truncated escapes — so **encode → parse round-trips exactly**.

### ⚠️ Breaking change (wire format)
Like #75/#82, this changes the emitted logfmt for values containing control characters / line separators / `TAB` (now escaped). Values without such characters are unaffected. This belongs in the next release's `CHANGELOG` as a `[CHANGE]` (deferred to the release-cut PR, alongside #89).

## Validation
- **201/201** tests on **net8.0** and **net10.0**; `dotnet build -c Release` → **0 warnings**.
- New tests: control chars + line separators are escaped-not-raw and round-trip; the parser decodes `\uXXXX` and tolerates malformed/truncated escapes. The tab/mixed/unicode-separator tests were updated to the new escaped output.
- Every hunk **mutation-verified**: dropping `IsEscapable` from the first pass, the `\uXXXX`-escape in the switch default, or the parser `\u` decode case each turns the corresponding test **RED**.

_Self-authored → informational review; AI does not merge._
